### PR TITLE
Insert receipt_email parameter

### DIFF
--- a/src/Message/AuthorizeRequest.php
+++ b/src/Message/AuthorizeRequest.php
@@ -17,6 +17,8 @@ class AuthorizeRequest extends AbstractRequest
         $data['description'] = $this->getDescription();
         $data['metadata'] = $this->getMetadata();
         $data['capture'] = 'false';
+        
+        $data['receipt_email'] = $this->getCard()->getEmail();
 
         if ($this->getCardReference()) {
             $data['customer'] = $this->getCardReference();


### PR DESCRIPTION
Stripe allows us to specify an email to send a receipt to, if receipts are enabled for the account - [relevant docs](https://stripe.com/docs/api#charge_object). So, let's provide the email if we have it!