### PR TITLE
Stripe Connect transaction_fee 

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,8 @@ The following gateways are provided by this package:
 For general usage instructions, please see the main [Omnipay](https://github.com/thephpleague/omnipay)
 repository.
 
+### Stripe.js
+
 The Stripe integration is fairly straight forward. Essentially you just pass
 a `token` field through to Stripe instead of the regular credit card data.
 
@@ -49,6 +51,20 @@ Simply pass this through to the gateway as `token`, instead of the usual `card` 
 $token = $_POST['stripeToken'];
 $response = $gateway->purchase(['amount' => '10.00', 'currency' => 'USD', 'token' => $token])->send();
 ```
+
+### Stripe Connect
+
+Stripe connect applications can charge an additional fee on top of Stripe's fees for charges they make on behalf of 
+their users. To do this you need to specify an additional `transactionFee` parameter as part of an authorize or purchase
+request.
+
+When a charge is refunded the transaction fee is refunded with an amount proportional to the amount of the charge
+refunded and by default this will come from your connected user's Stripe account effectively leaving them out of pocket.
+To refund from your (the applications) Stripe account instead you can pass a ``refundApplicationFee`` parameter with a
+boolean value of true as part of a refund request.
+
+Note: making requests with Stripe Connect specific parameters can only be made using the OAuth access token you received
+as part of the authorization process. Read more on Stripe Connect [here](https://stripe.com/docs/connect).
 
 ## Support
 

--- a/src/Message/AuthorizeRequest.php
+++ b/src/Message/AuthorizeRequest.php
@@ -7,6 +7,21 @@ namespace Omnipay\Stripe\Message;
  */
 class AuthorizeRequest extends AbstractRequest
 {
+    public function getApplicationFee()
+    {
+        return $this->getParameter('applicationFee');
+    }
+
+    public function getApplicationFeeInteger()
+    {
+        return (int) round($this->getApplicationFee() * pow(10, $this->getCurrencyDecimalPlaces()));
+    }
+
+    public function setApplicationFee($value)
+    {
+        return $this->setParameter('applicationFee', $value);
+    }
+
     public function getData()
     {
         $this->validate('amount', 'currency');
@@ -17,6 +32,10 @@ class AuthorizeRequest extends AbstractRequest
         $data['description'] = $this->getDescription();
         $data['metadata'] = $this->getMetadata();
         $data['capture'] = 'false';
+
+        if ($this->getApplicationFee()) {
+            $data['application_fee'] = $this->getApplicationFeeInteger();
+        }
 
         if ($this->getCardReference()) {
             $data['customer'] = $this->getCardReference();

--- a/src/Message/RefundRequest.php
+++ b/src/Message/RefundRequest.php
@@ -50,11 +50,28 @@ namespace Omnipay\Stripe\Message;
  */
 class RefundRequest extends AbstractRequest
 {
+    /**
+     * @return bool Whether the application fee should be refunded
+     */
     public function getRefundApplicationFee()
     {
         return $this->getParameter('refundApplicationFee');
     }
 
+    /**
+     * Whether to refund the application fee associated with a charge.
+     *
+     * From the {@link https://stripe.com/docs/api#create_refund Stripe docs}:
+     * Boolean indicating whether the application fee should be refunded
+     * when refunding this charge. If a full charge refund is given, the
+     * full application fee will be refunded. Else, the application fee
+     * will be refunded with an amount proportional to the amount of the
+     * charge refunded. An application fee can only be refunded by the
+     * application that created the charge.
+     *
+     * @param bool $value Whether the application fee should be refunded
+     * @return AbstractRequest
+     */
     public function setRefundApplicationFee($value)
     {
         return $this->setParameter('refundApplicationFee', $value);

--- a/src/Message/RefundRequest.php
+++ b/src/Message/RefundRequest.php
@@ -7,12 +7,26 @@ namespace Omnipay\Stripe\Message;
  */
 class RefundRequest extends AbstractRequest
 {
+    public function getRefundApplicationFee()
+    {
+        return $this->getParameter('refundApplicationFee');
+    }
+
+    public function setRefundApplicationFee($value)
+    {
+        return $this->setParameter('refundApplicationFee', $value);
+    }
+
     public function getData()
     {
         $this->validate('transactionReference', 'amount');
 
         $data = array();
         $data['amount'] = $this->getAmountInteger();
+
+        if ($this->getRefundApplicationFee()) {
+            $data['refund_application_fee'] = true;
+        }
 
         return $data;
     }

--- a/tests/Message/AuthorizeRequestTest.php
+++ b/tests/Message/AuthorizeRequestTest.php
@@ -18,6 +18,7 @@ class AuthorizeRequestTest extends TestCase
                 'metadata' => array(
                     'foo' => 'bar',
                 ),
+                'applicationFee' => '1.00'
             )
         );
     }
@@ -31,6 +32,7 @@ class AuthorizeRequestTest extends TestCase
         $this->assertSame('Order #42', $data['description']);
         $this->assertSame('false', $data['capture']);
         $this->assertSame(array('foo' => 'bar'), $data['metadata']);
+        $this->assertSame(100, $data['application_fee']);
     }
 
     /**

--- a/tests/Message/RefundRequestTest.php
+++ b/tests/Message/RefundRequestTest.php
@@ -10,7 +10,7 @@ class RefundRequestTest extends TestCase
     {
         $this->request = new RefundRequest($this->getHttpClient(), $this->getHttpRequest());
         $this->request->setTransactionReference('ch_12RgN9L7XhO9mI')
-            ->setAmount('10.00');
+            ->setAmount('10.00')->setRefundApplicationFee(true);
     }
 
     public function testEndpoint()
@@ -22,6 +22,12 @@ class RefundRequestTest extends TestCase
     {
         $data = $this->request->getData();
         $this->assertSame(1000, $data['amount']);
+    }
+
+    public function testRefundApplicationFee()
+    {
+        $data = $this->request->getData();
+        $this->assertTrue($data['refund_application_fee']);
     }
 
     public function testSendSuccess()


### PR DESCRIPTION
Stripe Connect allows applications to make calls to the Stripe API on behalf of a user via an OAuth access token. These commits allow the application to leverage (and refund) an application fee that is deducted from the amount transferred to a users Stripe account.