### PR TITLE
Split createCustomer and createCard, mega issue fix

### DIFF
--- a/runtests.sh
+++ b/runtests.sh
@@ -1,0 +1,25 @@
+#!/bin/sh
+
+#
+# Command line runner for unit tests for composer projects
+# (c) Del 2015 http://www.babel.com.au/
+# No Rights Reserved
+#
+
+#
+# Clean up after any previous test runs
+#
+mkdir -p documents
+rm -rf documents/coverage-html-new
+rm -f documents/coverage.xml
+
+#
+# Run phpunit
+#
+vendor/bin/phpunit --coverage-html documents/coverage-html-new --coverage-clover documents/coverage.xml
+
+if [ -d documents/coverage-html-new ]; then
+  rm -rf documents/coverage-html
+  mv documents/coverage-html-new documents/coverage-html
+fi
+

--- a/src/Gateway.php
+++ b/src/Gateway.php
@@ -147,6 +147,16 @@ class Gateway extends AbstractGateway
      * is transferred.  The transaction will need to be captured later
      * in order to effect payment. Uncaptured charges expire in 7 days.
      *
+     * Either a customerReference or a card is required.  If a customerReference
+     * is passed in then the cardReference must be the reference of a card
+     * assigned to the customer.  Otherwise, if you do not pass a customer ID,
+     * the card you provide must either be a token, like the ones returned by
+     * Stripe.js, or a dictionary containing a user's credit card details.
+     *
+     * IN OTHER WORDS: You cannot just pass a card reference into this request,
+     * you must also provide a customer reference if you want to use a stored
+     * card.
+     *
      * @param array $parameters
      * @return \Omnipay\Stripe\Message\AuthorizeRequest
      */
@@ -175,6 +185,16 @@ class Gateway extends AbstractGateway
      * is in test mode, the supplied card won't actually be charged, though
      * everything else will occur as if in live mode. (Stripe assumes that the
      * charge would have completed successfully). 
+     *
+     * Either a customerReference or a card is required.  If a customerReference
+     * is passed in then the cardReference must be the reference of a card
+     * assigned to the customer.  Otherwise, if you do not pass a customer ID,
+     * the card you provide must either be a token, like the ones returned by
+     * Stripe.js, or a dictionary containing a user's credit card details.
+     *
+     * IN OTHER WORDS: You cannot just pass a card reference into this request,
+     * you must also provide a customer reference if you want to use a stored
+     * card.
      *
      * @param array $parameters
      * @return \Omnipay\Stripe\Message\PurchaseRequest

--- a/src/Gateway.php
+++ b/src/Gateway.php
@@ -88,6 +88,11 @@ class Gateway extends AbstractGateway
         return 'Stripe';
     }
 
+    /**
+     * Get the gateway parameters
+     *
+     * @return array
+     */
     public function getDefaultParameters()
     {
         return array(
@@ -95,17 +100,53 @@ class Gateway extends AbstractGateway
         );
     }
 
+    /**
+     * Get the gateway API Key
+     *
+     * Authentication is by means of a single secret API key set as
+     * the apiKey parameter when creating the gateway object.
+     *
+     * @return string
+     */
     public function getApiKey()
     {
         return $this->getParameter('apiKey');
     }
 
+    /**
+     * Set the gateway API Key
+     *
+     * Authentication is by means of a single secret API key set as
+     * the apiKey parameter when creating the gateway object.
+     *
+     * Stripe accounts have test-mode API keys as well as live-mode
+     * API keys. These keys can be active at the same time. Data
+     * created with test-mode credentials will never hit the credit
+     * card networks and will never cost anyone money.
+     *
+     * Unlike some gateways, there is no test mode endpoint separate
+     * to the live mode endpoint, the Stripe API endpoint is the same
+     * for test and for live.
+     *
+     * Setting the testMode flag on this gateway has no effect.  To
+     * use test mode just use your test mode API key.
+     *
+     * @param string $value
+     * @return Gateway provides a fluent interface.
+     */
     public function setApiKey($value)
     {
         return $this->setParameter('apiKey', $value);
     }
 
     /**
+     * Authorize Request
+     *
+     * An Authorize request is similar to a purchase request but the
+     * charge issues an authorization (or pre-authorization), and no money
+     * is transferred.  The transaction will need to be captured later
+     * in order to effect payment. Uncaptured charges expire in 7 days.
+     *
      * @param array $parameters
      * @return \Omnipay\Stripe\Message\AuthorizeRequest
      */
@@ -115,6 +156,10 @@ class Gateway extends AbstractGateway
     }
 
     /**
+     * Capture Request
+     *
+     * Use this request to capture and process a previously created authorization.
+     *
      * @param array $parameters
      * @return \Omnipay\Stripe\Message\CaptureRequest
      */
@@ -124,6 +169,13 @@ class Gateway extends AbstractGateway
     }
 
     /**
+     * Purchase request.
+     *
+     * To charge a credit card, you create a new charge object. If your API key
+     * is in test mode, the supplied card won't actually be charged, though
+     * everything else will occur as if in live mode. (Stripe assumes that the
+     * charge would have completed successfully). 
+     *
      * @param array $parameters
      * @return \Omnipay\Stripe\Message\PurchaseRequest
      */
@@ -133,6 +185,17 @@ class Gateway extends AbstractGateway
     }
 
     /**
+     * Refund Request
+     *
+     * When you create a new refund, you must specify a
+     * charge to create it on.
+     *
+     * Creating a new refund will refund a charge that has
+     * previously been created but not yet refunded. Funds will
+     * be refunded to the credit or debit card that was originally
+     * charged. The fees you were originally charged are also
+     * refunded.
+     *
      * @param array $parameters
      * @return \Omnipay\Stripe\Message\RefundRequest
      */
@@ -142,6 +205,8 @@ class Gateway extends AbstractGateway
     }
 
     /**
+     * Fetch Transaction Request
+     *
      * @param array $parameters
      * @return \Omnipay\Stripe\Message\FetchTransactionRequest
      */
@@ -150,7 +215,21 @@ class Gateway extends AbstractGateway
         return $this->createRequest('\Omnipay\Stripe\Message\FetchTransactionRequest', $parameters);
     }
 
+    //
+    // Cards
+    // @link https://stripe.com/docs/api#cards
+    //
+
     /**
+     * Create Card
+     *
+     * This call can be used to create a new customer or add a card
+     * to an existing customer.  If a customerReference is passed in then
+     * a card is added to an existing customer.  If there is no
+     * customerReference passed in then a new customer is created.  The
+     * response in that case will then contain both a customer token
+     * and a card token, and is essentially the same as CreateCustomerRequest
+     *
      * @param array $parameters
      * @return \Omnipay\Stripe\Message\CreateCardRequest
      */
@@ -160,6 +239,19 @@ class Gateway extends AbstractGateway
     }
 
     /**
+     * Update Card
+     *
+     * If you need to update only some card details, like the billing
+     * address or expiration date, you can do so without having to re-enter
+     * the full card details. Stripe also works directly with card networks
+     * so that your customers can continue using your service without
+     * interruption.
+     *
+     * When you update a card, Stripe will automatically validate the card.
+     *
+     * This requires both a customerReference and a cardReference.
+     *
+     * @link https://stripe.com/docs/api#update_card
      * @param array $parameters
      * @return \Omnipay\Stripe\Message\UpdateCardRequest
      */
@@ -169,6 +261,29 @@ class Gateway extends AbstractGateway
     }
 
     /**
+     * Delete a card.
+     *
+     * This is normally used to delete a credit card from an existing
+     * customer.
+     *
+     * You can delete cards from a customer or recipient. If you delete a
+     * card that is currently the default card on a customer or recipient,
+     * the most recently added card will be used as the new default. If you
+     * delete the last remaining card on a customer or recipient, the
+     * default_card attribute on the card's owner will become null.
+     *
+     * Note that for cards belonging to customers, you may want to prevent
+     * customers on paid subscriptions from deleting all cards on file so
+     * that there is at least one default card for the next invoice payment
+     * attempt.
+     *
+     * In deference to the previous incarnation of this gateway, where
+     * all CreateCard requests added a new customer and the customer ID
+     * was used as the card ID, if a cardReference is passed in but no
+     * customerReference then we assume that the cardReference is in fact
+     * a customerReference and delete the customer.  This might be
+     * dangerous but it's the best way to ensure backwards compatibility.
+     *
      * @param array $parameters
      * @return \Omnipay\Stripe\Message\DeleteCardRequest
      */
@@ -177,7 +292,97 @@ class Gateway extends AbstractGateway
         return $this->createRequest('\Omnipay\Stripe\Message\DeleteCardRequest', $parameters);
     }
 
+    //
+    // Customers
+    // link: https://stripe.com/docs/api#customers
+    //
+    
     /**
+     * Create Customer
+     *
+     * Customer objects allow you to perform recurring charges and
+     * track multiple charges that are associated with the same customer.
+     * The API allows you to create, delete, and update your customers.
+     * You can retrieve individual customers as well as a list of all of
+     * your customers. 
+     *
+     * @param array $parameters
+     * @return \Omnipay\Stripe\Message\CreateCustomerRequest
+     */
+    public function createCustomer(array $parameters = array())
+    {
+        return $this->createRequest('\Omnipay\Stripe\Message\CreateCustomerRequest', $parameters);
+    }
+
+    /**
+     * Update Customer
+     *
+     * This request updates the specified customer by setting the values
+     * of the parameters passed. Any parameters not provided will be left
+     * unchanged. For example, if you pass the card parameter, that becomes
+     * the customer's active card to be used for all charges in the future,
+     * and the customer email address is updated to the email address
+     * on the card. When you update a customer to a new valid card: for
+     * each of the customer's current subscriptions, if the subscription
+     * is in the `past_due` state, then the latest unpaid, unclosed
+     * invoice for the subscription will be retried (note that this retry
+     * will not count as an automatic retry, and will not affect the next
+     * regularly scheduled payment for the invoice). (Note also that no
+     * invoices pertaining to subscriptions in the `unpaid` state, or
+     * invoices pertaining to canceled subscriptions, will be retried as
+     * a result of updating the customer's card.)
+     *
+     * This request accepts mostly the same arguments as the customer
+     * creation call. 
+     *
+     * @param array $parameters
+     * @return \Omnipay\Stripe\Message\CreateCustomerRequest
+     */
+    public function updateCustomer(array $parameters = array())
+    {
+        return $this->createRequest('\Omnipay\Stripe\Message\UpdateCustomerRequest', $parameters);
+    }
+
+    /**
+     * Delete a customer.
+     *
+     * Permanently deletes a customer. It cannot be undone. Also immediately
+     * cancels any active subscriptions on the customer. 
+     *
+     * @param array $parameters
+     * @return \Omnipay\Stripe\Message\DeleteCustomerRequest
+     */
+    public function deleteCustomer(array $parameters = array())
+    {
+        return $this->createRequest('\Omnipay\Stripe\Message\DeleteCustomerRequest', $parameters);
+    }
+
+    //
+    // Tokens
+    // @link https://stripe.com/docs/api#tokens
+    //
+    // This gateway does not currently have a CreateToken message.  In
+    // any case tokens are probably not what you are looking for because
+    // they are single use.  You probably want to create a Customer or
+    // Card reference instead.  This function is left here for further
+    // expansion.
+    //
+
+    /**
+     * Stripe Fetch Token Request
+     *
+     * Often you want to be able to charge credit cards or send payments
+     * to bank accounts without having to hold sensitive card information
+     * on your own servers. Stripe.js makes this easy in the browser, but
+     * you can use the same technique in other environments with our token API.
+     *
+     * Tokens can be created with your publishable API key, which can safely
+     * be embedded in downloadable applications like iPhone and Android apps.
+     * You can then use a token anywhere in our API that a card or bank account
+     * is accepted. Note that tokens are not meant to be stored or used more
+     * than once—to store these details for use later, you should create
+     * Customer or Recipient objects. 
+     *
      * @param array $parameters
      * @return \Omnipay\Stripe\Message\FetchTokenRequest
      */

--- a/src/Message/AbstractRequest.php
+++ b/src/Message/AbstractRequest.php
@@ -185,7 +185,9 @@ abstract class AbstractRequest extends \Omnipay\Common\Message\AbstractRequest
         $data['number'] = $card->getNumber();
         $data['exp_month'] = $card->getExpiryMonth();
         $data['exp_year'] = $card->getExpiryYear();
-        $data['cvc'] = $card->getCvv();
+        if (! empty($this->getCard()->getCvv())) {
+            $data['cvc'] = $card->getCvv();
+        }
         $data['name'] = $card->getName();
         $data['address_line1'] = $card->getAddress1();
         $data['address_line2'] = $card->getAddress2();

--- a/src/Message/AbstractRequest.php
+++ b/src/Message/AbstractRequest.php
@@ -185,7 +185,7 @@ abstract class AbstractRequest extends \Omnipay\Common\Message\AbstractRequest
         $data['number'] = $card->getNumber();
         $data['exp_month'] = $card->getExpiryMonth();
         $data['exp_year'] = $card->getExpiryYear();
-        if (! empty($this->getCard()->getCvv())) {
+        if ($this->getCard()->getCvv()) {
             $data['cvc'] = $card->getCvv();
         }
         $data['name'] = $card->getName();

--- a/src/Message/AbstractRequest.php
+++ b/src/Message/AbstractRequest.php
@@ -185,7 +185,7 @@ abstract class AbstractRequest extends \Omnipay\Common\Message\AbstractRequest
         $data['number'] = $card->getNumber();
         $data['exp_month'] = $card->getExpiryMonth();
         $data['exp_year'] = $card->getExpiryYear();
-        if ($this->getCard()->getCvv()) {
+        if ($card->getCvv()) {
             $data['cvc'] = $card->getCvv();
         }
         $data['name'] = $card->getName();

--- a/src/Message/AbstractRequest.php
+++ b/src/Message/AbstractRequest.php
@@ -65,7 +65,7 @@ abstract class AbstractRequest extends \Omnipay\Common\Message\AbstractRequest
      */
     public function getCardToken()
     {
-        return $this->getParameter('token');
+        return $this->getCardReference();
     }
 
     /**
@@ -73,7 +73,30 @@ abstract class AbstractRequest extends \Omnipay\Common\Message\AbstractRequest
      */
     public function setCardToken($value)
     {
-        return $this->setParameter('token', $value);
+        return $this->setCardReference($value);
+    }
+
+    /**
+     * Get the customer reference
+     *
+     * @return string
+     */
+    public function getCustomerReference()
+    {
+        return $this->getParameter('customerReference');
+    }
+
+    /**
+     * Set the customer reference
+     *
+     * Used when calling CreateCard on an existing customer.  If this
+     * parameter is not set then a new customer is created.
+     *
+     * @return AbstractRequest provides a fluent interface.
+     */
+    public function setCustomerReference($value)
+    {
+        return $this->setParameter('customerReference', $value);
     }
 
     public function getMetadata()
@@ -140,17 +163,18 @@ abstract class AbstractRequest extends \Omnipay\Common\Message\AbstractRequest
         $this->getCard()->validate();
 
         $data = array();
-        $data['number'] = $this->getCard()->getNumber();
-        $data['exp_month'] = $this->getCard()->getExpiryMonth();
-        $data['exp_year'] = $this->getCard()->getExpiryYear();
-        $data['cvc'] = $this->getCard()->getCvv();
-        $data['name'] = $this->getCard()->getName();
-        $data['address_line1'] = $this->getCard()->getAddress1();
-        $data['address_line2'] = $this->getCard()->getAddress2();
-        $data['address_city'] = $this->getCard()->getCity();
-        $data['address_zip'] = $this->getCard()->getPostcode();
-        $data['address_state'] = $this->getCard()->getState();
-        $data['address_country'] = $this->getCard()->getCountry();
+        $card = $this->getCard();
+        $data['number'] = $card->getNumber();
+        $data['exp_month'] = $card->getExpiryMonth();
+        $data['exp_year'] = $card->getExpiryYear();
+        $data['cvc'] = $card->getCvv();
+        $data['name'] = $card->getName();
+        $data['address_line1'] = $card->getAddress1();
+        $data['address_line2'] = $card->getAddress2();
+        $data['address_city'] = $card->getCity();
+        $data['address_zip'] = $card->getPostcode();
+        $data['address_state'] = $card->getState();
+        $data['address_country'] = $card->getCountry();
 
         return $data;
     }

--- a/src/Message/AuthorizeRequest.php
+++ b/src/Message/AuthorizeRequest.php
@@ -13,6 +13,16 @@ namespace Omnipay\Stripe\Message;
  * is transferred.  The transaction will need to be captured later
  * in order to effect payment. Uncaptured charges expire in 7 days.
  *
+ * Either a customerReference or a card is required.  If a customerReference
+ * is passed in then the cardReference must be the reference of a card
+ * assigned to the customer.  Otherwise, if you do not pass a customer ID,
+ * the card you provide must either be a token, like the ones returned by
+ * Stripe.js, or a dictionary containing a user's credit card details.
+ *
+ * IN OTHER WORDS: You cannot just pass a card reference into this request,
+ * you must also provide a customer reference if you want to use a stored
+ * card.
+ *
  * Example:
  *
  * <code>
@@ -73,8 +83,11 @@ class AuthorizeRequest extends AbstractRequest
         $data['metadata'] = $this->getMetadata();
         $data['capture'] = 'false';
 
-        if ($this->getCardReference()) {
-            $data['customer'] = $this->getCardReference();
+        if ($this->getCustomerReference()) {
+            $data['customer'] = $this->getCustomerReference();
+            if ($this->getCardReference()) {
+                $data['card'] = $this->getCardReference();
+            }
         } elseif ($this->getToken()) {
             $data['card'] = $this->getToken();
         } elseif ($this->getCard()) {

--- a/src/Message/CreateCardRequest.php
+++ b/src/Message/CreateCardRequest.php
@@ -8,11 +8,20 @@ namespace Omnipay\Stripe\Message;
 /**
  * Stripe Create Credit Card Request
  *
- * This doesn't actually create a card, it creates a customer.
+ * In the stripe system, creating a credit card requires passing
+ * a customer ID.  The card is then added to the customer's account.
+ * If the customer has no default card then the newly added
+ * card becomes the customer's default card.
  *
- * See issue #8
+ * This call can be used to create a new customer or add a card
+ * to an existing customer.  If a customerReference is passed in then
+ * a card is added to an existing customer.  If there is no
+ * customerReference passed in then a new customer is created.  The
+ * response in that case will then contain both a customer token
+ * and a card token, and is essentially the same as CreateCustomerRequest
  *
- * @link https://github.com/thephpleague/omnipay-stripe/issues/8
+ * @see CreateCustomerRequest
+ * @link https://stripe.com/docs/api#create_card
  */
 class CreateCardRequest extends AbstractRequest
 {
@@ -21,9 +30,10 @@ class CreateCardRequest extends AbstractRequest
         $data = array();
         $data['description'] = $this->getDescription();
 
-        if ($this->getToken()) {
-            $data['card'] = $this->getToken();
+        if ($this->getReference()) {
+            $data['card'] = $this->getReference();
         } elseif ($this->getCard()) {
+            $this->getCard()->validate();
             $data['card'] = $this->getCardData();
             $data['email'] = $this->getCard()->getEmail();
         } else {
@@ -36,6 +46,12 @@ class CreateCardRequest extends AbstractRequest
 
     public function getEndpoint()
     {
-        return $this->endpoint.'/customers';
+        if ($this->getCustomerReference()) {
+            // Create a new customer and card
+            return $this->endpoint . '/customers';
+        }
+        // Create a new card on an existing customer
+        return $this->endpoint . '/customers/' .
+            $this->getCustomerReference() . '/cards';
     }
 }

--- a/src/Message/CreateCardRequest.php
+++ b/src/Message/CreateCardRequest.php
@@ -28,16 +28,28 @@ class CreateCardRequest extends AbstractRequest
     public function getData()
     {
         $data = array();
-        $data['description'] = $this->getDescription();
+        
+        // Only set the description if we are creating a new customer.
+        if (! $this->getCustomerReference()) {
+            $data['description'] = $this->getDescription();
+        }
 
-        if ($this->getReference()) {
-            $data['card'] = $this->getReference();
+        // If a token is passed then use the token.
+        if ($this->getToken()) {
+            $data['card'] = $this->getToken();
+
+        // If a card is passed then use the card.
         } elseif ($this->getCard()) {
             $this->getCard()->validate();
             $data['card'] = $this->getCardData();
-            $data['email'] = $this->getCard()->getEmail();
+
+            // Only set the email address if we are creating a new customer.
+            if (! $this->getCustomerReference()) {
+                $data['email'] = $this->getCard()->getEmail();
+            }
+
+        // one of token or card is required
         } else {
-            // one of token or card is required
             $this->validate('card');
         }
 
@@ -47,11 +59,11 @@ class CreateCardRequest extends AbstractRequest
     public function getEndpoint()
     {
         if ($this->getCustomerReference()) {
-            // Create a new customer and card
-            return $this->endpoint . '/customers';
+            // Create a new card on an existing customer
+            return $this->endpoint . '/customers/' .
+                $this->getCustomerReference() . '/cards';
         }
-        // Create a new card on an existing customer
-        return $this->endpoint . '/customers/' .
-            $this->getCustomerReference() . '/cards';
+        // Create a new customer and card
+        return $this->endpoint . '/customers';
     }
 }

--- a/src/Message/CreateCardRequest.php
+++ b/src/Message/CreateCardRequest.php
@@ -20,6 +20,42 @@ namespace Omnipay\Stripe\Message;
  * response in that case will then contain both a customer token
  * and a card token, and is essentially the same as CreateCustomerRequest
  *
+ * Example.  This example assumes that you have already created a
+ * customer, and that the customer reference is stored in $customer_id.
+ * See CreateCustomerRequest for the first part of this transaction.
+ *
+ * <code>
+ *   // Create a credit card object
+ *   // This card can be used for testing.
+ *   // The CreditCard object is also used for creating customers.
+ *   $new_card = new CreditCard(array(
+ *               'firstName'    => 'Example',
+ *               'lastName'     => 'Customer',
+ *               'number'       => '5555555555554444',
+ *               'expiryMonth'  => '01',
+ *               'expiryYear'   => '2020',
+ *               'cvv'          => '456',
+ *               'email'                 => 'customer@example.com',
+ *               'billingAddress1'       => '1 Lower Creek Road',
+ *               'billingCountry'        => 'AU',
+ *               'billingCity'           => 'Upper Swan',
+ *               'billingPostcode'       => '6999',
+ *               'billingState'          => 'WA',
+ *   ));
+ *
+ *   // Do a create card transaction on the gateway
+ *   $response = $gateway->createCard(array(
+ *       'card'              => $new_card,
+ *       'customerReference' => $customer_id,
+ *   ))->send();
+ *   if ($response->isSuccessful()) {
+ *       echo "Gateway createCard was successful.\n";
+ *       // Find the card ID
+ *       $card_id = $response->getCardReference();
+ *       echo "Card ID = " . $card_id . "\n";
+ *   }
+ * </code>
+ *
  * @see CreateCustomerRequest
  * @link https://stripe.com/docs/api#create_card
  */

--- a/src/Message/CreateCustomerRequest.php
+++ b/src/Message/CreateCustomerRequest.php
@@ -1,0 +1,40 @@
+<?php
+/**
+ * Stripe Create Customer Request
+ */
+
+namespace Omnipay\Stripe\Message;
+
+/**
+ * Stripe Create Customer Request
+ *
+ * Customer objects allow you to perform recurring charges and
+ * track multiple charges that are associated with the same customer.
+ * The API allows you to create, delete, and update your customers.
+ * You can retrieve individual customers as well as a list of all of
+ * your customers. 
+ *
+ * @link https://stripe.com/docs/api#customers
+ */
+class CreateCustomerRequest extends AbstractRequest
+{
+    public function getData()
+    {
+        $data = array();
+        $data['description'] = $this->getDescription();
+
+        if ($this->getToken()) {
+            $data['card'] = $this->getToken();
+        } elseif ($this->getCard()) {
+            $data['card'] = $this->getCardData();
+            $data['email'] = $this->getCard()->getEmail();
+        }
+
+        return $data;
+    }
+
+    public function getEndpoint()
+    {
+        return $this->endpoint . '/customers';
+    }
+}

--- a/src/Message/CreateCustomerRequest.php
+++ b/src/Message/CreateCustomerRequest.php
@@ -12,7 +12,52 @@ namespace Omnipay\Stripe\Message;
  * track multiple charges that are associated with the same customer.
  * The API allows you to create, delete, and update your customers.
  * You can retrieve individual customers as well as a list of all of
- * your customers. 
+ * your customers.
+ *
+ * Example:
+ *
+ * <code>
+ *   // Create a gateway for the Stripe Gateway
+ *   // (routes to GatewayFactory::create)
+ *   $gateway = Omnipay::create('Stripe');
+ *
+ *   // Initialise the gateway
+ *   $gateway->initialize(array(
+ *       'apiKey' => 'MyApiKey',
+ *   ));
+ *
+ *   // Create a credit card object
+ *   // This card can be used for testing.
+ *   // The CreditCard object is also used for creating customers.
+ *   $card = new CreditCard(array(
+ *               'firstName'    => 'Example',
+ *               'lastName'     => 'Customer',
+ *               'number'       => '4242424242424242',
+ *               'expiryMonth'  => '01',
+ *               'expiryYear'   => '2020',
+ *               'cvv'          => '123',
+ *               'email'                 => 'customer@example.com',
+ *               'billingAddress1'       => '1 Scrubby Creek Road',
+ *               'billingCountry'        => 'AU',
+ *               'billingCity'           => 'Scrubby Creek',
+ *               'billingPostcode'       => '4999',
+ *               'billingState'          => 'QLD',
+ *   ));
+ *
+ *   // Do a create customer transaction on the gateway
+ *   $response = $gateway->createCustomer(array(
+ *       'card'                     => $card,
+ *   ))->send();
+ *   if ($response->isSuccessful()) {
+ *       echo "Gateway createCustomer was successful.\n";
+ *       // Find the customer ID
+ *       $customer_id = $response->getCustomerReference();
+ *       echo "Customer ID = " . $customer_id . "\n";
+ *       // Find the card ID
+ *       $card_id = $response->getCardReference();
+ *       echo "Card ID = " . $card_id . "\n";
+ *   }
+ * </code>
  *
  * @link https://stripe.com/docs/api#customers
  */

--- a/src/Message/DeleteCardRequest.php
+++ b/src/Message/DeleteCardRequest.php
@@ -49,7 +49,7 @@ class DeleteCardRequest extends AbstractRequest
     {
         if ($this->getCustomerReference()) {
             // Delete a card from a customer
-            return $this->endpoint . '/customers/' . 
+            return $this->endpoint . '/customers/' .
                 $this->getCustomerReference() . '/cards/' .
                 $this->getCardReference();
         }

--- a/src/Message/DeleteCardRequest.php
+++ b/src/Message/DeleteCardRequest.php
@@ -51,7 +51,7 @@ class DeleteCardRequest extends AbstractRequest
             // Delete a card from a customer
             return $this->endpoint . '/customers/' . 
                 $this->getCustomerReference() . '/cards/' .
-                $this-getCardReference();
+                $this->getCardReference();
         }
         // Delete the customer.  Oops?
         return $this->endpoint.'/customers/' . $this->getCardReference();

--- a/src/Message/DeleteCardRequest.php
+++ b/src/Message/DeleteCardRequest.php
@@ -8,8 +8,26 @@ namespace Omnipay\Stripe\Message;
 /**
  * Stripe Delete Credit Card Request
  *
- * This needs further work and/or explanation because it requires
- * a customer ID.
+ * This is normally used to delete a credit card from an existing
+ * customer.
+ *
+ * You can delete cards from a customer or recipient. If you delete a
+ * card that is currently the default card on a customer or recipient,
+ * the most recently added card will be used as the new default. If you
+ * delete the last remaining card on a customer or recipient, the
+ * default_card attribute on the card's owner will become null.
+ *
+ * Note that for cards belonging to customers, you may want to prevent
+ * customers on paid subscriptions from deleting all cards on file so
+ * that there is at least one default card for the next invoice payment
+ * attempt.
+ *
+ * In deference to the previous incarnation of this gateway, where
+ * all CreateCard requests added a new customer and the customer ID
+ * was used as the card ID, if a cardReference is passed in but no
+ * customerReference then we assume that the cardReference is in fact
+ * a customerReference and delete the customer.  This might be
+ * dangerous but it's the best way to ensure backwards compatibility.
  *
  * @link https://stripe.com/docs/api#delete_card
  */
@@ -29,6 +47,13 @@ class DeleteCardRequest extends AbstractRequest
 
     public function getEndpoint()
     {
-        return $this->endpoint.'/customers/'.$this->getCardReference();
+        if ($this->getCustomerReference()) {
+            // Delete a card from a customer
+            return $this->endpoint . '/customers/' . 
+                $this->getCustomerReference() . '/cards/' .
+                $this-getCardReference();
+        }
+        // Delete the customer.  Oops?
+        return $this->endpoint.'/customers/' . $this->getCardReference();
     }
 }

--- a/src/Message/DeleteCustomerRequest.php
+++ b/src/Message/DeleteCustomerRequest.php
@@ -1,0 +1,34 @@
+<?php
+/**
+ * Stripe Delete Customer Request
+ */
+
+namespace Omnipay\Stripe\Message;
+
+/**
+ * Stripe Delete Customer Request
+ *
+ * Permanently deletes a customer. It cannot be undone. Also immediately
+ * cancels any active subscriptions on the customer. 
+ *
+ * @link https://stripe.com/docs/api#delete_customer
+ */
+class DeleteCustomerRequest extends AbstractRequest
+{
+    public function getData()
+    {
+        $this->validate('customerReference');
+
+        return null;
+    }
+
+    public function getHttpMethod()
+    {
+        return 'DELETE';
+    }
+
+    public function getEndpoint()
+    {
+        return $this->endpoint . '/customers/' . $this->getCustomerReference();
+    }
+}

--- a/src/Message/FetchTokenRequest.php
+++ b/src/Message/FetchTokenRequest.php
@@ -8,6 +8,18 @@ namespace Omnipay\Stripe\Message;
 /**
  * Stripe Fetch Token Request
  *
+ * Often you want to be able to charge credit cards or send payments
+ * to bank accounts without having to hold sensitive card information
+ * on your own servers. Stripe.js makes this easy in the browser, but
+ * you can use the same technique in other environments with our token API.
+ *
+ * Tokens can be created with your publishable API key, which can safely
+ * be embedded in downloadable applications like iPhone and Android apps.
+ * You can then use a token anywhere in our API that a card or bank account
+ * is accepted. Note that tokens are not meant to be stored or used more
+ * than once—to store these details for use later, you should create
+ * Customer or Recipient objects. 
+ *
  * @link https://stripe.com/docs/api#tokens
  */
 class FetchTokenRequest extends AbstractRequest

--- a/src/Message/PurchaseRequest.php
+++ b/src/Message/PurchaseRequest.php
@@ -8,6 +8,11 @@ namespace Omnipay\Stripe\Message;
 /**
  * Stripe Purchase Request
  *
+ * To charge a credit card, you create a new charge object. If your API key
+ * is in test mode, the supplied card won't actually be charged, though
+ * everything else will occur as if in live mode. (Stripe assumes that the
+ * charge would have completed successfully). 
+ *
  * Example:
  *
  * <code>

--- a/src/Message/Response.php
+++ b/src/Message/Response.php
@@ -36,6 +36,9 @@ class Response extends AbstractResponse
         if (isset($this->data['object']) && 'charge' === $this->data['object']) {
             return $this->data['id'];
         }
+        if (isset($this->data['error']) && isset($this->data['error']['charge'])) {
+            return $this->data['error']['charge'];
+        }
 
         return null;
     }

--- a/src/Message/Response.php
+++ b/src/Message/Response.php
@@ -50,6 +50,11 @@ class Response extends AbstractResponse
         if (isset($this->data['object']) && 'customer' === $this->data['object']) {
             return $this->data['id'];
         }
+        if (isset($this->data['object']) && 'card' === $this->data['object']) {
+            if (! empty($this->data['customer'])) {
+                return $this->data['customer'];
+            }
+        }
 
         return null;
     }
@@ -66,6 +71,11 @@ class Response extends AbstractResponse
                 return $this->data['default_card'];
             }
         }
+        if (isset($this->data['object']) && 'card' === $this->data['object']) {
+            if (! empty($this->data['id'])) {
+                return $this->data['id'];
+            }
+        }
 
         return null;
     }
@@ -75,7 +85,7 @@ class Response extends AbstractResponse
      *
      * @return string|null
      */
-    public function getReference()
+    public function getToken()
     {
         if (isset($this->data['object']) && 'token' === $this->data['object']) {
             return $this->data['id'];

--- a/src/Message/Response.php
+++ b/src/Message/Response.php
@@ -73,6 +73,9 @@ class Response extends AbstractResponse
             if (! empty($this->data['default_card'])) {
                 return $this->data['default_card'];
             }
+            if (! empty($this->data['id'])) {
+                return $this->data['id'];
+            }
         }
         if (isset($this->data['object']) && 'card' === $this->data['object']) {
             if (! empty($this->data['id'])) {

--- a/src/Message/Response.php
+++ b/src/Message/Response.php
@@ -41,6 +41,20 @@ class Response extends AbstractResponse
     }
 
     /**
+     * Get a customer reference, for createCustomer requests.
+     *
+     * @return string|null
+     */
+    public function getCustomerReference()
+    {
+        if (isset($this->data['object']) && 'customer' === $this->data['object']) {
+            return $this->data['id'];
+        }
+
+        return null;
+    }
+
+    /**
      * Get a card reference, for createCard or createCustomer requests.
      *
      * @return string|null
@@ -48,7 +62,9 @@ class Response extends AbstractResponse
     public function getCardReference()
     {
         if (isset($this->data['object']) && 'customer' === $this->data['object']) {
-            return $this->data['id'];
+            if (! empty($this->data['default_card'])) {
+                return $this->data['default_card'];
+            }
         }
 
         return null;
@@ -59,7 +75,7 @@ class Response extends AbstractResponse
      *
      * @return string|null
      */
-    public function getToken()
+    public function getReference()
     {
         if (isset($this->data['object']) && 'token' === $this->data['object']) {
             return $this->data['id'];

--- a/src/Message/UpdateCardRequest.php
+++ b/src/Message/UpdateCardRequest.php
@@ -8,8 +8,15 @@ namespace Omnipay\Stripe\Message;
 /**
  * Stripe Update Credit Card Request
  *
- * This needs further work and/or explanation because it requires
- * a customer ID.
+ * If you need to update only some card details, like the billing
+ * address or expiration date, you can do so without having to re-enter
+ * the full card details. Stripe also works directly with card networks
+ * so that your customers can continue using your service without
+ * interruption.
+ *
+ * When you update a card, Stripe will automatically validate the card.
+ *
+ * This requires both a customerReference and a cardReference.
  *
  * @link https://stripe.com/docs/api#update_card
  */
@@ -17,23 +24,59 @@ class UpdateCardRequest extends AbstractRequest
 {
     public function getData()
     {
-        $data = array();
-        $data['description'] = $this->getDescription();
-
-        if ($this->getToken()) {
-            $data['card'] = $this->getToken();
-        } elseif ($this->getCard()) {
-            $data['card'] = $this->getCardData();
-            $data['email'] = $this->getCard()->getEmail();
-        }
-
         $this->validate('cardReference');
-
+        $this->validate('customerReference');
+        $data = $this->getCardData();
         return $data;
     }
 
     public function getEndpoint()
     {
-        return $this->endpoint.'/customers/'.$this->getCardReference();
+        return $this->endpoint . '/customers/' . $this->getCustomerReference() .
+            '/cards/' . $this->getCardReference();
+    }
+
+    /**
+     * Get the card data.
+     *
+     * This request uses a slightly different format for card data to
+     * the other requests and does not require the card data to be
+     * complete in full (or valid).
+     *
+     * @return array
+     */
+    protected function getCardData()
+    {
+        $data = array();
+        $card = $this->getCard();
+        if ($card->getExpiryMonth()) {
+            $data['exp_month'] = $card->getExpiryMonth();
+        }
+        if ($card->getExpiryYear()) {
+            $data['exp_year'] = $card->getExpiryYear();
+        }
+        if ($card->getName()) {
+            $data['name'] = $card->getName();
+        }
+        if ($card->getAddress1()) {
+            $data['address_line1'] = $card->getAddress1();
+        }
+        if ($card->getAddress2()) {
+            $data['address_line2'] = $card->getAddress2();
+        }
+        if ($card->getCity()) {
+            $data['address_city'] = $card->getCity();
+        }
+        if ($card->getPostcode()) {
+            $data['address_zip'] = $card->getPostcode();
+        }
+        if ($card->getState()) {
+            $data['address_state'] = $card->getState();
+        }
+        if ($card->getCountry()) {
+            $data['address_country'] = $card->getCountry();
+        }
+
+        return $data;
     }
 }

--- a/src/Message/UpdateCardRequest.php
+++ b/src/Message/UpdateCardRequest.php
@@ -24,6 +24,9 @@ class UpdateCardRequest extends AbstractRequest
 {
     public function getData()
     {
+        $this->validate('cardReference');
+        $this->validate('customerReference');
+
         $data = array();
         $data['description'] = $this->getDescription();
 
@@ -36,9 +39,6 @@ class UpdateCardRequest extends AbstractRequest
             $data['email'] = $this->getCard()->getEmail();
         }
 
-        $this->validate('cardReference');
-        $this->validate('customerReference');
-        $data = $this->getCardData();
         return $data;
     }
 
@@ -61,32 +61,37 @@ class UpdateCardRequest extends AbstractRequest
     {
         $data = array();
         $card = $this->getCard();
-        if ($card->getExpiryMonth()) {
-            $data['exp_month'] = $card->getExpiryMonth();
-        }
-        if ($card->getExpiryYear()) {
-            $data['exp_year'] = $card->getExpiryYear();
-        }
-        if ($card->getName()) {
-            $data['name'] = $card->getName();
-        }
-        if ($card->getAddress1()) {
-            $data['address_line1'] = $card->getAddress1();
-        }
-        if ($card->getAddress2()) {
-            $data['address_line2'] = $card->getAddress2();
-        }
-        if ($card->getCity()) {
-            $data['address_city'] = $card->getCity();
-        }
-        if ($card->getPostcode()) {
-            $data['address_zip'] = $card->getPostcode();
-        }
-        if ($card->getState()) {
-            $data['address_state'] = $card->getState();
-        }
-        if ($card->getCountry()) {
-            $data['address_country'] = $card->getCountry();
+        if (! empty($card)) {
+            if ($card->getExpiryMonth()) {
+                $data['exp_month'] = $card->getExpiryMonth();
+            }
+            if ($card->getExpiryYear()) {
+                $data['exp_year'] = $card->getExpiryYear();
+            }
+            if ($card->getName()) {
+                $data['name'] = $card->getName();
+            }
+            if ($card->getNumber()) {
+                $data['number'] = $card->getNumber();
+            }
+            if ($card->getAddress1()) {
+                $data['address_line1'] = $card->getAddress1();
+            }
+            if ($card->getAddress2()) {
+                $data['address_line2'] = $card->getAddress2();
+            }
+            if ($card->getCity()) {
+                $data['address_city'] = $card->getCity();
+            }
+            if ($card->getPostcode()) {
+                $data['address_zip'] = $card->getPostcode();
+            }
+            if ($card->getState()) {
+                $data['address_state'] = $card->getState();
+            }
+            if ($card->getCountry()) {
+                $data['address_country'] = $card->getCountry();
+            }
         }
 
         return $data;

--- a/src/Message/UpdateCustomerRequest.php
+++ b/src/Message/UpdateCustomerRequest.php
@@ -1,0 +1,60 @@
+<?php
+/**
+ * Stripe Update Customer Request
+ */
+
+namespace Omnipay\Stripe\Message;
+
+/**
+ * Stripe Update Customer Request
+ *
+ * Customer objects allow you to perform recurring charges and
+ * track multiple charges that are associated with the same customer.
+ * The API allows you to create, delete, and update your customers.
+ * You can retrieve individual customers as well as a list of all of
+ * your customers.
+ *
+ * This request updates the specified customer by setting the values
+ * of the parameters passed. Any parameters not provided will be left
+ * unchanged. For example, if you pass the card parameter, that becomes
+ * the customer's active card to be used for all charges in the future,
+ * and the customer email address is updated to the email address
+ * on the card. When you update a customer to a new valid card: for
+ * each of the customer's current subscriptions, if the subscription
+ * is in the `past_due` state, then the latest unpaid, unclosed
+ * invoice for the subscription will be retried (note that this retry
+ * will not count as an automatic retry, and will not affect the next
+ * regularly scheduled payment for the invoice). (Note also that no
+ * invoices pertaining to subscriptions in the `unpaid` state, or
+ * invoices pertaining to canceled subscriptions, will be retried as
+ * a result of updating the customer's card.)
+ *
+ * This request accepts mostly the same arguments as the customer
+ * creation call. 
+ *
+ * @link https://stripe.com/docs/api#update_customer
+ */
+class UpdateCustomerRequest extends AbstractRequest
+{
+    public function getData()
+    {
+        $this->validate('customerReference');
+        $data = array();
+        $data['description'] = $this->getDescription();
+
+        if ($this->getToken()) {
+            $data['card'] = $this->getToken();
+        } elseif ($this->getCard()) {
+            $this->getCard()->validate();
+            $data['card'] = $this->getCardData();
+            $data['email'] = $this->getCard()->getEmail();
+        }
+
+        return $data;
+    }
+
+    public function getEndpoint()
+    {
+        return $this->endpoint . '/customers/' . $this->getCustomerReference();
+    }
+}

--- a/tests/Message/AbstractRequestTest.php
+++ b/tests/Message/AbstractRequestTest.php
@@ -2,14 +2,14 @@
 
 namespace Omnipay\Stripe\Message;
 
-use Mockery as m;
+use Mockery;
 use Omnipay\Tests\TestCase;
 
 class AbstractRequestTest extends TestCase
 {
     public function setUp()
     {
-        $this->request = m::mock('\Omnipay\Stripe\Message\AbstractRequest')->makePartial();
+        $this->request = Mockery::mock('\Omnipay\Stripe\Message\AbstractRequest')->makePartial();
         $this->request->initialize();
     }
 
@@ -23,6 +23,32 @@ class AbstractRequestTest extends TestCase
     {
         $this->assertSame($this->request, $this->request->setToken('abc123'));
         $this->assertSame('abc123', $this->request->getToken());
+    }
+
+    public function testSource()
+    {
+        $this->assertSame($this->request, $this->request->setSource('abc123'));
+        $this->assertSame('abc123', $this->request->getSource());
+    }
+
+    public function testCardData()
+    {
+        $card = $this->getValidCard();
+        $this->request->setCard($card);
+        $data = $this->request->getCardData();
+
+        $this->assertSame($card['number'], $data['number']);
+        $this->assertSame($card['cvv'], $data['cvc']);
+    }
+
+    public function testCardDataEmptyCvv()
+    {
+        $card = $this->getValidCard();
+        $card['cvv'] = '';
+        $this->request->setCard($card);
+        $data = $this->request->getCardData();
+
+        $this->assertTrue(empty($data['cvv']));
     }
 
     public function testMetadata()

--- a/tests/Message/AbstractRequestTest.php
+++ b/tests/Message/AbstractRequestTest.php
@@ -13,10 +13,15 @@ class AbstractRequestTest extends TestCase
         $this->request->initialize();
     }
 
+    public function testCardReference()
+    {
+        $this->assertSame($this->request, $this->request->setCardReference('abc123'));
+        $this->assertSame('abc123', $this->request->getCardReference());
+    }
+
     public function testCardToken()
     {
-        $this->assertSame($this->request, $this->request->setCardToken('abc123'));
-        $this->assertSame('abc123', $this->request->getCardToken());
+        $this->assertSame($this->request, $this->request->setToken('abc123'));
         $this->assertSame('abc123', $this->request->getToken());
     }
 

--- a/tests/Message/AuthorizeRequestTest.php
+++ b/tests/Message/AuthorizeRequestTest.php
@@ -87,7 +87,7 @@ class AuthorizeRequestTest extends TestCase
 
         $this->assertFalse($response->isSuccessful());
         $this->assertFalse($response->isRedirect());
-        $this->assertNull($response->getTransactionReference());
+        $this->assertSame('ch_1IUAZQWFYrPooM', $response->getTransactionReference());
         $this->assertNull($response->getCardReference());
         $this->assertSame('Your card was declined', $response->getMessage());
     }

--- a/tests/Message/AuthorizeRequestTest.php
+++ b/tests/Message/AuthorizeRequestTest.php
@@ -52,7 +52,7 @@ class AuthorizeRequestTest extends TestCase
         $data = $this->request->getData();
 
         $this->assertSame('abc', $data['customer']);
-        $this->assertSame('xyz', $data['card']);
+        $this->assertSame('xyz', $data['source']);
     }
 
     public function testDataWithToken()

--- a/tests/Message/AuthorizeRequestTest.php
+++ b/tests/Message/AuthorizeRequestTest.php
@@ -45,10 +45,12 @@ class AuthorizeRequestTest extends TestCase
 
     public function testDataWithCardReference()
     {
+        $this->request->setCustomerReference('abc');
         $this->request->setCardReference('xyz');
         $data = $this->request->getData();
 
-        $this->assertSame('xyz', $data['customer']);
+        $this->assertSame('abc', $data['customer']);
+        $this->assertSame('xyz', $data['card']);
     }
 
     public function testDataWithToken()

--- a/tests/Message/CreateCardRequestTest.php
+++ b/tests/Message/CreateCardRequestTest.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace Omnipay\Stripe\Message;
+
+use Omnipay\Tests\TestCase;
+
+class CreateCardRequestTest extends TestCase
+{
+    public function setUp()
+    {
+        $this->request = new CreateCardRequest($this->getHttpClient(), $this->getHttpRequest());
+        $this->request->setCard($this->getValidCard());
+    }
+
+    public function testEndpoint()
+    {
+        $this->request->setCustomerReference('');
+        $this->assertSame('https://api.stripe.com/v1/customers', $this->request->getEndpoint());
+        $this->request->setCustomerReference('cus_1MZSEtqSghKx99');
+        $this->assertSame('https://api.stripe.com/v1/customers/cus_1MZSEtqSghKx99/cards', $this->request->getEndpoint());
+    }
+
+    public function testDataWithCard()
+    {
+        $card = $this->getValidCard();
+        $this->request->setCard($card);
+        $data = $this->request->getData();
+
+        $this->assertSame($card['number'], $data['card']['number']);
+    }
+
+    public function testSendSuccess()
+    {
+        $this->setMockHttpResponse('CreateCardSuccess.txt');
+        $response = $this->request->send();
+
+        $this->assertTrue($response->isSuccessful());
+        $this->assertFalse($response->isRedirect());
+        $this->assertNull($response->getTransactionReference());
+        $this->assertSame('cus_5i75ZdvSgIgLdW', $response->getCustomerReference());
+        $this->assertSame('card_15WgqxIobxWFFmzdk5V9z3g9', $response->getCardReference());
+        $this->assertNull($response->getMessage());
+    }
+
+    public function testSendFailure()
+    {
+        $this->setMockHttpResponse('CreateCardFailure.txt');
+        $response = $this->request->send();
+
+        $this->assertFalse($response->isSuccessful());
+        $this->assertFalse($response->isRedirect());
+        $this->assertNull($response->getTransactionReference());
+        $this->assertNull($response->getCardReference());
+        $this->assertSame('You must provide an integer value for \'exp_year\'.', $response->getMessage());
+    }
+}

--- a/tests/Message/CreateCustomerRequestTest.php
+++ b/tests/Message/CreateCustomerRequestTest.php
@@ -1,0 +1,60 @@
+<?php
+
+namespace Omnipay\Stripe\Message;
+
+use Omnipay\Tests\TestCase;
+
+class CreateCustomerRequestTest extends TestCase
+{
+    public function setUp()
+    {
+        $this->request = new CreateCustomerRequest($this->getHttpClient(), $this->getHttpRequest());
+        $this->request->setCard($this->getValidCard());
+    }
+
+    public function testEndpoint()
+    {
+        $this->assertSame('https://api.stripe.com/v1/customers', $this->request->getEndpoint());
+    }
+
+    public function testDataWithToken()
+    {
+        $this->request->setToken('xyz');
+        $data = $this->request->getData();
+
+        $this->assertSame('xyz', $data['card']);
+    }
+
+    public function testDataWithCard()
+    {
+        $card = $this->getValidCard();
+        $this->request->setCard($card);
+        $data = $this->request->getData();
+
+        $this->assertSame($card['number'], $data['card']['number']);
+    }
+
+    public function testSendSuccess()
+    {
+        $this->setMockHttpResponse('CreateCustomerSuccess.txt');
+        $response = $this->request->send();
+
+        $this->assertTrue($response->isSuccessful());
+        $this->assertFalse($response->isRedirect());
+        $this->assertNull($response->getTransactionReference());
+        $this->assertSame('cus_1MZSEtqSghKx99', $response->getCustomerReference());
+        $this->assertNull($response->getMessage());
+    }
+
+    public function testSendFailure()
+    {
+        $this->setMockHttpResponse('CreateCustomerFailure.txt');
+        $response = $this->request->send();
+
+        $this->assertFalse($response->isSuccessful());
+        $this->assertFalse($response->isRedirect());
+        $this->assertNull($response->getTransactionReference());
+        $this->assertNull($response->getCardReference());
+        $this->assertSame('You must provide an integer value for \'exp_year\'.', $response->getMessage());
+    }
+}

--- a/tests/Message/CreateCustomerRequestTest.php
+++ b/tests/Message/CreateCustomerRequestTest.php
@@ -43,6 +43,7 @@ class CreateCustomerRequestTest extends TestCase
         $this->assertFalse($response->isRedirect());
         $this->assertNull($response->getTransactionReference());
         $this->assertSame('cus_1MZSEtqSghKx99', $response->getCustomerReference());
+        $this->assertSame('card_15WhVwIobxWFFmzdQ3QBSwNi', $response->getCardReference());
         $this->assertNull($response->getMessage());
     }
 

--- a/tests/Message/DeleteCardRequestTest.php
+++ b/tests/Message/DeleteCardRequestTest.php
@@ -14,7 +14,12 @@ class DeleteCardRequestTest extends TestCase
 
     public function testEndpoint()
     {
+        $this->request->setCustomerReference('');
+        $this->request->setCardReference('cus_1MZSEtqSghKx99');
         $this->assertSame('https://api.stripe.com/v1/customers/cus_1MZSEtqSghKx99', $this->request->getEndpoint());
+        $this->request->setCustomerReference('cus_1MZSEtqSghKx99');
+        $this->request->setCardReference('card_15Wg7vIobxWFFmzdvC5fVY67');
+        $this->assertSame('https://api.stripe.com/v1/customers/cus_1MZSEtqSghKx99/cards/card_15Wg7vIobxWFFmzdvC5fVY67', $this->request->getEndpoint());
     }
 
     public function testSendSuccess()

--- a/tests/Message/DeleteCustomerRequestTest.php
+++ b/tests/Message/DeleteCustomerRequestTest.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace Omnipay\Stripe\Message;
+
+use Omnipay\Tests\TestCase;
+
+class DeleteCustomerRequestTest extends TestCase
+{
+    public function setUp()
+    {
+        $this->request = new DeleteCustomerRequest($this->getHttpClient(), $this->getHttpRequest());
+        $this->request->setCustomerReference('cus_1MZSEtqSghKx99');
+    }
+
+    public function testEndpoint()
+    {
+        $this->assertSame('https://api.stripe.com/v1/customers/cus_1MZSEtqSghKx99', $this->request->getEndpoint());
+    }
+
+    public function testSendSuccess()
+    {
+        $this->setMockHttpResponse('DeleteCustomerSuccess.txt');
+        $response = $this->request->send();
+
+        $this->assertTrue($response->isSuccessful());
+        $this->assertFalse($response->isRedirect());
+        $this->assertNull($response->getTransactionReference());
+        $this->assertNull($response->getCustomerReference());
+        $this->assertNull($response->getMessage());
+    }
+
+    public function testSendFailure()
+    {
+        $this->setMockHttpResponse('DeleteCustomerFailure.txt');
+        $response = $this->request->send();
+
+        $this->assertFalse($response->isSuccessful());
+        $this->assertFalse($response->isRedirect());
+        $this->assertNull($response->getTransactionReference());
+        $this->assertNull($response->getCustomerReference());
+        $this->assertSame('No such customer: cus_1MZeNih5LdKxDq', $response->getMessage());
+    }
+}

--- a/tests/Message/PurchaseRequestTest.php
+++ b/tests/Message/PurchaseRequestTest.php
@@ -43,7 +43,7 @@ class PurchaseRequestTest extends TestCase
 
         $this->assertFalse($response->isSuccessful());
         $this->assertFalse($response->isRedirect());
-        $this->assertNull($response->getTransactionReference());
+        $this->assertSame('ch_1IUAZQWFYrPooM', $response->getTransactionReference());
         $this->assertNull($response->getCardReference());
         $this->assertSame('Your card was declined', $response->getMessage());
     }

--- a/tests/Message/ResponseTest.php
+++ b/tests/Message/ResponseTest.php
@@ -25,7 +25,7 @@ class ResponseTest extends TestCase
 
         $this->assertFalse($response->isSuccessful());
         $this->assertFalse($response->isRedirect());
-        $this->assertNull($response->getTransactionReference());
+        $this->assertSame('ch_1IUAZQWFYrPooM', $response->getTransactionReference());
         $this->assertNull($response->getCardReference());
         $this->assertSame('Your card was declined', $response->getMessage());
     }

--- a/tests/Message/ResponseTest.php
+++ b/tests/Message/ResponseTest.php
@@ -30,75 +30,75 @@ class ResponseTest extends TestCase
         $this->assertSame('Your card was declined', $response->getMessage());
     }
 
-    public function testCreateCardSuccess()
+    public function testCreateCustomerSuccess()
     {
-        $httpResponse = $this->getMockHttpResponse('CreateCardSuccess.txt');
+        $httpResponse = $this->getMockHttpResponse('CreateCustomerSuccess.txt');
         $response = new Response($this->getMockRequest(), $httpResponse->json());
 
         $this->assertTrue($response->isSuccessful());
         $this->assertFalse($response->isRedirect());
         $this->assertNull($response->getTransactionReference());
-        $this->assertSame('cus_1MZSEtqSghKx99', $response->getCardReference());
+        $this->assertSame('cus_1MZSEtqSghKx99', $response->getCustomerReference());
         $this->assertNull($response->getMessage());
     }
 
-    public function testCreateCardFailure()
+    public function testCreateCustomerFailure()
     {
-        $httpResponse = $this->getMockHttpResponse('CreateCardFailure.txt');
+        $httpResponse = $this->getMockHttpResponse('CreateCustomerFailure.txt');
         $response = new Response($this->getMockRequest(), $httpResponse->json());
 
         $this->assertFalse($response->isSuccessful());
         $this->assertFalse($response->isRedirect());
         $this->assertNull($response->getTransactionReference());
-        $this->assertNull($response->getCardReference());
+        $this->assertNull($response->getCustomerReference());
         $this->assertSame('You must provide an integer value for \'exp_year\'.', $response->getMessage());
     }
 
-    public function testUpdateCardSuccess()
+    public function testUpdateCustomerSuccess()
     {
-        $httpResponse = $this->getMockHttpResponse('UpdateCardSuccess.txt');
+        $httpResponse = $this->getMockHttpResponse('UpdateCustomerSuccess.txt');
         $response = new Response($this->getMockRequest(), $httpResponse->json());
 
         $this->assertTrue($response->isSuccessful());
         $this->assertFalse($response->isRedirect());
         $this->assertNull($response->getTransactionReference());
-        $this->assertSame('cus_1MZeNih5LdKxDq', $response->getCardReference());
+        $this->assertSame('cus_1MZeNih5LdKxDq', $response->getCustomerReference());
         $this->assertNull($response->getMessage());
     }
 
-    public function testUpdateCardFailure()
+    public function testUpdateCustomerFailure()
     {
-        $httpResponse = $this->getMockHttpResponse('UpdateCardFailure.txt');
+        $httpResponse = $this->getMockHttpResponse('UpdateCustomerFailure.txt');
         $response = new Response($this->getMockRequest(), $httpResponse->json());
 
         $this->assertFalse($response->isSuccessful());
         $this->assertFalse($response->isRedirect());
         $this->assertNull($response->getTransactionReference());
-        $this->assertNull($response->getCardReference());
+        $this->assertNull($response->getCustomerReference());
         $this->assertSame('No such customer: cus_1MZeNih5LdKxDq', $response->getMessage());
     }
 
-    public function testDeleteCardSuccess()
+    public function testDeleteCustomerSuccess()
     {
-        $httpResponse = $this->getMockHttpResponse('DeleteCardSuccess.txt');
+        $httpResponse = $this->getMockHttpResponse('DeleteCustomerSuccess.txt');
         $response = new Response($this->getMockRequest(), $httpResponse->json());
 
         $this->assertTrue($response->isSuccessful());
         $this->assertFalse($response->isRedirect());
         $this->assertNull($response->getTransactionReference());
-        $this->assertNull($response->getCardReference());
+        $this->assertNull($response->getCustomerReference());
         $this->assertNull($response->getMessage());
     }
 
-    public function testDeleteCardFailure()
+    public function testDeleteCustomerFailure()
     {
-        $httpResponse = $this->getMockHttpResponse('DeleteCardFailure.txt');
+        $httpResponse = $this->getMockHttpResponse('DeleteCustomerFailure.txt');
         $response = new Response($this->getMockRequest(), $httpResponse->json());
 
         $this->assertFalse($response->isSuccessful());
         $this->assertFalse($response->isRedirect());
         $this->assertNull($response->getTransactionReference());
-        $this->assertNull($response->getCardReference());
+        $this->assertNull($response->getCustomerReference());
         $this->assertSame('No such customer: cus_1MZeNih5LdKxDq', $response->getMessage());
     }
 }

--- a/tests/Message/UpdateCardRequestTest.php
+++ b/tests/Message/UpdateCardRequestTest.php
@@ -32,7 +32,7 @@ class UpdateCardRequestTest extends TestCase
         $this->request->setCard($card);
         $data = $this->request->getData();
 
-        $this->assertSame($card['billingAddress1'], $data['address_line1']);
+        $this->assertSame($card['billingAddress1'], $data['source']['address_line1']);
         $this->assertSame($card['number'], $data['source']['number']);
     }
 

--- a/tests/Message/UpdateCardRequestTest.php
+++ b/tests/Message/UpdateCardRequestTest.php
@@ -9,20 +9,13 @@ class UpdateCardRequestTest extends TestCase
     public function setUp()
     {
         $this->request = new UpdateCardRequest($this->getHttpClient(), $this->getHttpRequest());
-        $this->request->setCardReference('cus_1MZSEtqSghKx99');
+        $this->request->setCustomerReference('cus_1MZSEtqSghKx99');
+        $this->request->setCardReference('card_15Wg7vIobxWFFmzdvC5fVY67');
     }
 
     public function testEndpoint()
     {
-        $this->assertSame('https://api.stripe.com/v1/customers/cus_1MZSEtqSghKx99', $this->request->getEndpoint());
-    }
-
-    public function testDataWithToken()
-    {
-        $this->request->setToken('xyz');
-        $data = $this->request->getData();
-
-        $this->assertSame('xyz', $data['card']);
+        $this->assertSame('https://api.stripe.com/v1/customers/cus_1MZSEtqSghKx99/cards/card_15Wg7vIobxWFFmzdvC5fVY67', $this->request->getEndpoint());
     }
 
     public function testDataWithCard()
@@ -31,30 +24,6 @@ class UpdateCardRequestTest extends TestCase
         $this->request->setCard($card);
         $data = $this->request->getData();
 
-        $this->assertSame($card['number'], $data['card']['number']);
-    }
-
-    public function testSendSuccess()
-    {
-        $this->setMockHttpResponse('UpdateCardSuccess.txt');
-        $response = $this->request->send();
-
-        $this->assertTrue($response->isSuccessful());
-        $this->assertFalse($response->isRedirect());
-        $this->assertNull($response->getTransactionReference());
-        $this->assertSame('cus_1MZeNih5LdKxDq', $response->getCardReference());
-        $this->assertNull($response->getMessage());
-    }
-
-    public function testSendFailure()
-    {
-        $this->setMockHttpResponse('UpdateCardFailure.txt');
-        $response = $this->request->send();
-
-        $this->assertFalse($response->isSuccessful());
-        $this->assertFalse($response->isRedirect());
-        $this->assertNull($response->getTransactionReference());
-        $this->assertNull($response->getCardReference());
-        $this->assertSame('No such customer: cus_1MZeNih5LdKxDq', $response->getMessage());
+        $this->assertSame($card['billingAddress1'], $data['address_line1']);
     }
 }

--- a/tests/Message/UpdateCustomerRequestTest.php
+++ b/tests/Message/UpdateCustomerRequestTest.php
@@ -4,27 +4,17 @@ namespace Omnipay\Stripe\Message;
 
 use Omnipay\Tests\TestCase;
 
-class CreateCardRequestTest extends TestCase
+class UpdateCustomerRequestTest extends TestCase
 {
     public function setUp()
     {
-        $this->request = new CreateCardRequest($this->getHttpClient(), $this->getHttpRequest());
-        $this->request->setCard($this->getValidCard());
+        $this->request = new UpdateCustomerRequest($this->getHttpClient(), $this->getHttpRequest());
+        $this->request->setCustomerReference('cus_1MZSEtqSghKx99');
     }
 
     public function testEndpoint()
     {
-        $this->assertSame('https://api.stripe.com/v1/customers', $this->request->getEndpoint());
-    }
-
-    /**
-     * @expectedException \Omnipay\Common\Exception\InvalidRequestException
-     * @expectedExceptionMessage The card parameter is required
-     */
-    public function testCard()
-    {
-        $this->request->setCard(null);
-        $this->request->getData();
+        $this->assertSame('https://api.stripe.com/v1/customers/cus_1MZSEtqSghKx99', $this->request->getEndpoint());
     }
 
     public function testDataWithToken()
@@ -46,25 +36,25 @@ class CreateCardRequestTest extends TestCase
 
     public function testSendSuccess()
     {
-        $this->setMockHttpResponse('CreateCardSuccess.txt');
+        $this->setMockHttpResponse('UpdateCustomerSuccess.txt');
         $response = $this->request->send();
 
         $this->assertTrue($response->isSuccessful());
         $this->assertFalse($response->isRedirect());
         $this->assertNull($response->getTransactionReference());
-        $this->assertSame('cus_1MZSEtqSghKx99', $response->getCardReference());
+        $this->assertSame('cus_1MZeNih5LdKxDq', $response->getCustomerReference());
         $this->assertNull($response->getMessage());
     }
 
     public function testSendFailure()
     {
-        $this->setMockHttpResponse('CreateCardFailure.txt');
+        $this->setMockHttpResponse('UpdateCustomerFailure.txt');
         $response = $this->request->send();
 
         $this->assertFalse($response->isSuccessful());
         $this->assertFalse($response->isRedirect());
         $this->assertNull($response->getTransactionReference());
-        $this->assertNull($response->getCardReference());
-        $this->assertSame('You must provide an integer value for \'exp_year\'.', $response->getMessage());
+        $this->assertNull($response->getCustomerReference());
+        $this->assertSame('No such customer: cus_1MZeNih5LdKxDq', $response->getMessage());
     }
 }

--- a/tests/Mock/CreateCardSuccess.txt
+++ b/tests/Mock/CreateCardSuccess.txt
@@ -2,40 +2,31 @@ HTTP/1.1 200 OK
 Server: nginx
 Date: Tue, 26 Feb 2013 16:11:12 GMT
 Content-Type: application/json;charset=utf-8
-Content-Length: 694
 Connection: keep-alive
 Access-Control-Max-Age: 300
 Access-Control-Allow-Credentials: true
 Cache-Control: no-cache, no-store
 
 {
-  "object": "customer",
-  "created": 1361895072,
-  "id": "cus_1MZSEtqSghKx99",
-  "livemode": false,
-  "description": "fdsa",
-  "active_card": {
+    "id": "card_15WgqxIobxWFFmzdk5V9z3g9",
     "object": "card",
-    "last4": "4242",
-    "type": "Visa",
-    "exp_month": 9,
-    "exp_year": 2019,
-    "fingerprint": "dfB0t0avO0bWr9eY",
+    "last4": "4444",
+    "brand": "MasterCard",
+    "funding": "credit",
+    "exp_month": 1,
+    "exp_year": 2020,
+    "fingerprint": "JM5ri11gcDo8UgkV",
     "country": "US",
-    "name": "fdjsk fdjksl",
-    "address_line1": "",
+    "name": "Another Customer",
+    "address_line1": "1 Downa Creek Road",
     "address_line2": "",
-    "address_city": "",
-    "address_state": "",
-    "address_zip": "",
-    "address_country": "",
+    "address_city": "Upper Swan",
+    "address_state": "WA",
+    "address_zip": "6999",
+    "address_country": "AU",
     "cvc_check": "pass",
     "address_line1_check": "pass",
-    "address_zip_check": "pass"
-  },
-  "email": null,
-  "delinquent": false,
-  "subscription": null,
-  "discount": null,
-  "account_balance": 0
+    "address_zip_check": "pass",
+    "dynamic_last4": null,
+    "customer": "cus_5i75ZdvSgIgLdW"
 }

--- a/tests/Mock/CreateCustomerFailure.txt
+++ b/tests/Mock/CreateCustomerFailure.txt
@@ -1,0 +1,17 @@
+HTTP/1.1 402 Payment Required
+Server: nginx
+Date: Tue, 26 Feb 2013 16:17:02 GMT
+Content-Type: application/json;charset=utf-8
+Content-Length: 139
+Connection: keep-alive
+Access-Control-Max-Age: 300
+Access-Control-Allow-Credentials: true
+Cache-Control: no-cache, no-store
+
+{
+  "error": {
+    "message": "You must provide an integer value for 'exp_year'.",
+    "type": "card_error",
+    "param": "exp_year"
+  }
+}

--- a/tests/Mock/CreateCustomerSuccess.txt
+++ b/tests/Mock/CreateCustomerSuccess.txt
@@ -1,0 +1,41 @@
+HTTP/1.1 200 OK
+Server: nginx
+Date: Tue, 26 Feb 2013 16:11:12 GMT
+Content-Type: application/json;charset=utf-8
+Content-Length: 694
+Connection: keep-alive
+Access-Control-Max-Age: 300
+Access-Control-Allow-Credentials: true
+Cache-Control: no-cache, no-store
+
+{
+  "object": "customer",
+  "created": 1361895072,
+  "id": "cus_1MZSEtqSghKx99",
+  "livemode": false,
+  "description": "fdsa",
+  "active_card": {
+    "object": "card",
+    "last4": "4242",
+    "type": "Visa",
+    "exp_month": 9,
+    "exp_year": 2019,
+    "fingerprint": "dfB0t0avO0bWr9eY",
+    "country": "US",
+    "name": "fdjsk fdjksl",
+    "address_line1": "",
+    "address_line2": "",
+    "address_city": "",
+    "address_state": "",
+    "address_zip": "",
+    "address_country": "",
+    "cvc_check": "pass",
+    "address_line1_check": "pass",
+    "address_zip_check": "pass"
+  },
+  "email": null,
+  "delinquent": false,
+  "subscription": null,
+  "discount": null,
+  "account_balance": 0
+}

--- a/tests/Mock/CreateCustomerSuccess.txt
+++ b/tests/Mock/CreateCustomerSuccess.txt
@@ -2,7 +2,6 @@ HTTP/1.1 200 OK
 Server: nginx
 Date: Tue, 26 Feb 2013 16:11:12 GMT
 Content-Type: application/json;charset=utf-8
-Content-Length: 694
 Connection: keep-alive
 Access-Control-Max-Age: 300
 Access-Control-Allow-Credentials: true
@@ -14,6 +13,7 @@ Cache-Control: no-cache, no-store
   "id": "cus_1MZSEtqSghKx99",
   "livemode": false,
   "description": "fdsa",
+  "default_card": "card_15WhVwIobxWFFmzdQ3QBSwNi",
   "active_card": {
     "object": "card",
     "last4": "4242",

--- a/tests/Mock/DeleteCustomerFailure.txt
+++ b/tests/Mock/DeleteCustomerFailure.txt
@@ -1,0 +1,17 @@
+HTTP/1.1 404 Not Found
+Server: nginx
+Date: Tue, 26 Feb 2013 16:32:51 GMT
+Content-Type: application/json;charset=utf-8
+Content-Length: 131
+Connection: keep-alive
+Access-Control-Max-Age: 300
+Access-Control-Allow-Credentials: true
+Cache-Control: no-cache, no-store
+
+{
+  "error": {
+    "type": "invalid_request_error",
+    "message": "No such customer: cus_1MZeNih5LdKxDq",
+    "param": "id"
+  }
+}

--- a/tests/Mock/DeleteCustomerSuccess.txt
+++ b/tests/Mock/DeleteCustomerSuccess.txt
@@ -1,0 +1,14 @@
+HTTP/1.1 200 OK
+Server: nginx
+Date: Tue, 26 Feb 2013 16:33:08 GMT
+Content-Type: application/json;charset=utf-8
+Content-Length: 52
+Connection: keep-alive
+Access-Control-Max-Age: 300
+Access-Control-Allow-Credentials: true
+Cache-Control: no-cache, no-store
+
+{
+  "deleted": true,
+  "id": "cus_1MZSEtqSghKx99"
+}

--- a/tests/Mock/UpdateCustomerFailure.txt
+++ b/tests/Mock/UpdateCustomerFailure.txt
@@ -1,0 +1,17 @@
+HTTP/1.1 404 Not Found
+Server: nginx
+Date: Tue, 26 Feb 2013 16:32:51 GMT
+Content-Type: application/json;charset=utf-8
+Content-Length: 131
+Connection: keep-alive
+Access-Control-Max-Age: 300
+Access-Control-Allow-Credentials: true
+Cache-Control: no-cache, no-store
+
+{
+  "error": {
+    "type": "invalid_request_error",
+    "message": "No such customer: cus_1MZeNih5LdKxDq",
+    "param": "id"
+  }
+}

--- a/tests/Mock/UpdateCustomerSuccess.txt
+++ b/tests/Mock/UpdateCustomerSuccess.txt
@@ -1,0 +1,23 @@
+HTTP/1.1 200 OK
+Server: nginx
+Date: Tue, 26 Feb 2013 16:11:12 GMT
+Content-Type: application/json;charset=utf-8
+Content-Length: 694
+Connection: keep-alive
+Access-Control-Max-Age: 300
+Access-Control-Allow-Credentials: true
+Cache-Control: no-cache, no-store
+
+{
+  "object": "customer",
+  "created": 1365771516,
+  "id": "cus_1MZeNih5LdKxDq",
+  "livemode": false,
+  "description": "fdsa",
+  "active_card": null,
+  "email": null,
+  "delinquent": false,
+  "subscription": null,
+  "discount": null,
+  "account_balance": 0
+}


### PR DESCRIPTION
This PR splits the former createCard functionality (which actually created a customer) into separate createCustomer and createCard requests, as well as fixing issues related to using a customer ID as if it was a card ID.

The stripe gateway actually requires a customer to be created before storing a card in the gateway.  This is not unusual -- many other gateways also require this, e.g. Pin.  I have started a topic for discussion on the omnipay google group about this here: https://groups.google.com/forum/#!topic/omnipay/8Ujt6nX1DKk -- the best way to handle this might be to add additional code to Omnipay Common to determine when a gateway requires a customer object to be created whenever a card object is required.  e.g. adding a new function such as gatewayRequiresCustomerBeforeCard(), etc.

The functionality now allows additional card objects to be added under an existing customer object using CreateCard.  UpdateCustomer now has the ability to change and/or replace an existing customer's default card, as well as the ability to change other customer details if required, e.g. description, email.

I have left behind a backwards compatibility shim whereby if CreateCard is called with card details and no customer reference then a new customer is created.  Both the customer reference and the card reference can now be extracted separately from the return response.  The potential backwards compatibility break caused by purchase() on a card reference now also requring a customer reference as well as the card reference is a non-issue because it never worked before anyway (since attempting to provide the customer reference as a card reference, or providing a card reference with no customer reference, isn't valid -- see issue #6 ).

This fixes issue #8 because it changes the way that updateCard works -- it no longer updates a customer but now correctly updates a card, part of which can be updated.

This fixes issue #6 because it now supports both a customer reference and a card reference on a purchase or authorize request.

I have also added a fix for issue #7 by returning the transaction ID for a failed payment.  I believe that this is unique to stripe but may be useful for some use cases, e.g. retrying or logging failed payments, etc.

Additional test cases and documentation were added -- mostly by moving *Card functionality cases to *Customer and adding additional cases for *Card.  Test case mock responses have been validated against the gateway, which has recently changed some output parameters but not in a way that disrupts backwards compatibility with any of the test cases here.

Lastly -- sorry about you having to read all of the above.  I write long documents because I don't have time to write short ones.

TL;DR It was brokeded before, I fixded it.