### PR TITLE
Void transactions

### DIFF
--- a/src/Gateway.php
+++ b/src/Gateway.php
@@ -143,6 +143,15 @@ class Gateway extends AbstractGateway
 
     /**
      * @param array $parameters
+     * @return \Omnipay\Stripe\Message\VoidRequest
+     */
+    public function void(array $parameters = array())
+    {
+        return $this->createRequest('\Omnipay\Stripe\Message\VoidRequest', $parameters);
+    }
+
+    /**
+     * @param array $parameters
      * @return \Omnipay\Stripe\Message\FetchTransactionRequest
      */
     public function fetchTransaction(array $parameters = array())

--- a/src/Message/VoidRequest.php
+++ b/src/Message/VoidRequest.php
@@ -1,0 +1,50 @@
+<?php
+/**
+ * Stripe Void Request
+ */
+
+namespace Omnipay\Stripe\Message;
+
+/**
+ * Stripe Void Request
+ *
+ * Stripe does not support voiding, per se, but
+ * we treat it as a full refund.
+ *
+ * See RefundRequest for additional information
+ *
+ * Example -- note this example assumes that the purchase has been successful
+ * and that the transaction ID returned from the purchase is held in $sale_id.
+ * See PurchaseRequest for the first part of this example transaction:
+ *
+ * <code>
+ *   // Do a void transaction on the gateway
+ *   $transaction = $gateway->void(array(
+ *       'transactionReference' => $sale_id,
+ *   ));
+ *   $response = $transaction->send();
+ *   if ($response->isSuccessful()) {
+ *       echo "Void transaction was successful!\n";
+ *       $void_id = $response->getTransactionReference();
+ *       echo "Transaction reference = " . $void_id . "\n";
+ *   }
+ * </code>
+ *
+ * @see RefundRequest
+ * @see Omnipay\Stripe\Gateway
+ * @link https://stripe.com/docs/api#create_refund
+ */
+class VoidRequest extends AbstractRequest
+{
+    public function getData()
+    {
+        $this->validate('transactionReference');
+
+        return null;
+    }
+
+    public function getEndpoint()
+    {
+        return $this->endpoint.'/charges/'.$this->getTransactionReference().'/refund';
+    }
+}

--- a/tests/GatewayTest.php
+++ b/tests/GatewayTest.php
@@ -45,6 +45,13 @@ class GatewayTest extends GatewayTestCase
         $this->assertSame('10.00', $request->getAmount());
     }
 
+    public function testVoid()
+    {
+        $request = $this->gateway->void();
+
+        $this->assertInstanceOf('Omnipay\Stripe\Message\VoidRequest', $request);
+    }
+
     public function testFetchTransaction()
     {
         $request = $this->gateway->fetchTransaction(array());

--- a/tests/Message/VoidRequestTest.php
+++ b/tests/Message/VoidRequestTest.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace Omnipay\Stripe\Message;
+
+use Omnipay\Tests\TestCase;
+
+class VoidRequestTest extends TestCase
+{
+    public function setUp()
+    {
+        $this->request = new VoidRequest($this->getHttpClient(), $this->getHttpRequest());
+        $this->request->setTransactionReference('ch_12RgN9L7XhO9mI');
+    }
+
+    public function testEndpoint()
+    {
+        $this->assertSame('https://api.stripe.com/v1/charges/ch_12RgN9L7XhO9mI/refund', $this->request->getEndpoint());
+    }
+
+    public function testSendSuccess()
+    {
+        $this->setMockHttpResponse('VoidSuccess.txt');
+        $response = $this->request->send();
+
+        $this->assertTrue($response->isSuccessful());
+        $this->assertFalse($response->isRedirect());
+        $this->assertSame('ch_12RgN9L7XhO9mI', $response->getTransactionReference());
+        $this->assertNull($response->getCardReference());
+        $this->assertNull($response->getMessage());
+    }
+
+    public function testSendError()
+    {
+        $this->setMockHttpResponse('VoidFailure.txt');
+        $response = $this->request->send();
+
+        $this->assertFalse($response->isSuccessful());
+        $this->assertFalse($response->isRedirect());
+        $this->assertNull($response->getTransactionReference());
+        $this->assertNull($response->getCardReference());
+        $this->assertSame('Charge ch_12RgN9L7XhO9mI has already been refunded.', $response->getMessage());
+    }
+}

--- a/tests/Mock/VoidFailure.txt
+++ b/tests/Mock/VoidFailure.txt
@@ -1,0 +1,3 @@
+HTTP/1.1 200 OK
+
+{"error":{"message":"Charge ch_12RgN9L7XhO9mI has already been refunded."}}

--- a/tests/Mock/VoidSuccess.txt
+++ b/tests/Mock/VoidSuccess.txt
@@ -1,0 +1,3 @@
+HTTP/1.1 200 OK
+
+{"id":"ch_12RgN9L7XhO9mI","object": "charge"}


### PR DESCRIPTION
Currently the RefundRequest validates "amount". However, amount is actually optional when processing refunds and defaults to the entire charge. See https://stripe.com/docs/api#create_refund

While it would have been a much simpler change to remove the amount validation for refunds, I thought it more made sense to add this as a "void" feature for Stripe instead.