### PR TITLE
Bug fix for refund_application_fee

### DIFF
--- a/src/Message/RefundRequest.php
+++ b/src/Message/RefundRequest.php
@@ -85,7 +85,7 @@ class RefundRequest extends AbstractRequest
         $data['amount'] = $this->getAmountInteger();
 
         if ($this->getRefundApplicationFee()) {
-            $data['refund_application_fee'] = true;
+            $data['refund_application_fee'] = "true";
         }
 
         return $data;

--- a/src/Message/VoidRequest.php
+++ b/src/Message/VoidRequest.php
@@ -34,17 +34,16 @@ namespace Omnipay\Stripe\Message;
  * @see Omnipay\Stripe\Gateway
  * @link https://stripe.com/docs/api#create_refund
  */
-class VoidRequest extends AbstractRequest
+class VoidRequest extends RefundRequest
 {
     public function getData()
     {
         $this->validate('transactionReference');
 
-        return null;
-    }
+        if ($this->getRefundApplicationFee()) {
+            $data['refund_application_fee'] = "true";
+        }
 
-    public function getEndpoint()
-    {
-        return $this->endpoint.'/charges/'.$this->getTransactionReference().'/refund';
+        return null;
     }
 }

--- a/tests/Message/RefundRequestTest.php
+++ b/tests/Message/RefundRequestTest.php
@@ -27,7 +27,7 @@ class RefundRequestTest extends TestCase
     public function testRefundApplicationFee()
     {
         $data = $this->request->getData();
-        $this->assertTrue($data['refund_application_fee']);
+        $this->assertEquals("true", $data['refund_application_fee']);
     }
 
     public function testSendSuccess()


### PR DESCRIPTION
fa2ad6105e67fc8f283ff44908700647ee10f754 included the `refund_application_fee` parameter. Had two minor issues with it.

* Parameter was missing from Void requests. I modified VoidRequest class to extend RefundRequest
* Set the value to boolean `true`, which Guzzle converts to integer `1` instead of string `"true"`. Stripe expects a string value `"true"` or `"false"`. See https://github.com/guzzle/guzzle/issues/588