### PR TITLE
bug fix for refunding application fee on a Void request

### DIFF
--- a/src/Message/VoidRequest.php
+++ b/src/Message/VoidRequest.php
@@ -40,10 +40,11 @@ class VoidRequest extends RefundRequest
     {
         $this->validate('transactionReference');
 
+        $data = array();
         if ($this->getRefundApplicationFee()) {
             $data['refund_application_fee'] = "true";
         }
 
-        return null;
+        return $data;
     }
 }

--- a/tests/Message/VoidRequestTest.php
+++ b/tests/Message/VoidRequestTest.php
@@ -9,12 +9,19 @@ class VoidRequestTest extends TestCase
     public function setUp()
     {
         $this->request = new VoidRequest($this->getHttpClient(), $this->getHttpRequest());
-        $this->request->setTransactionReference('ch_12RgN9L7XhO9mI');
+        $this->request->setTransactionReference('ch_12RgN9L7XhO9mI')
+            ->setRefundApplicationFee(true);
     }
 
     public function testEndpoint()
     {
         $this->assertSame('https://api.stripe.com/v1/charges/ch_12RgN9L7XhO9mI/refund', $this->request->getEndpoint());
+    }
+
+    public function testRefundApplicationFee()
+    {
+        $data = $this->request->getData();
+        $this->assertEquals("true", $data['refund_application_fee']);
     }
 
     public function testSendSuccess()


### PR DESCRIPTION
Ahh- the Void request was not returning the `$data` array so the `refund_application_fee` parameter was discarded. I updated the test to check that this works in the future. Sorry about that.