### PR TITLE
Optional statement_descriptor parameter

### DIFF
--- a/src/Message/AuthorizeRequest.php
+++ b/src/Message/AuthorizeRequest.php
@@ -77,6 +77,16 @@ class AuthorizeRequest extends AbstractRequest
         return $this->setParameter('applicationFee', $value);
     }
 
+    public function getStatementDescriptor()
+    {
+        return $this->getParameter('statementDescriptor');
+    }
+
+    public function setStatementDescriptor($value)
+    {
+        return $this->setParameter('statementDescriptor', $value);
+    }
+
     public function getData()
     {
         $this->validate('amount', 'currency');
@@ -88,6 +98,9 @@ class AuthorizeRequest extends AbstractRequest
         $data['metadata'] = $this->getMetadata();
         $data['capture'] = 'false';
 
+        if ($this->getStatementDescriptor()) {
+            $data['statement_descriptor'] = $this->getStatementDescriptor();
+        }
         if ($this->getApplicationFee()) {
             $data['application_fee'] = $this->getApplicationFeeInteger();
         }

--- a/src/Message/AuthorizeRequest.php
+++ b/src/Message/AuthorizeRequest.php
@@ -84,6 +84,8 @@ class AuthorizeRequest extends AbstractRequest
 
     public function setStatementDescriptor($value)
     {
+        $value = str_replace(['<', '>', '"', '\''], '', $value);
+
         return $this->setParameter('statementDescriptor', $value);
     }
 

--- a/src/Message/AuthorizeRequest.php
+++ b/src/Message/AuthorizeRequest.php
@@ -84,7 +84,7 @@ class AuthorizeRequest extends AbstractRequest
 
     public function setStatementDescriptor($value)
     {
-        $value = str_replace(['<', '>', '"', '\''], '', $value);
+        $value = str_replace(array('<', '>', '"', '\''), '', $value);
 
         return $this->setParameter('statementDescriptor', $value);
     }

--- a/tests/Message/AuthorizeRequestTest.php
+++ b/tests/Message/AuthorizeRequestTest.php
@@ -53,6 +53,14 @@ class AuthorizeRequestTest extends TestCase
         $this->assertSame('xyz', $data['customer']);
     }
 
+    public function testDataWithStatementDescriptor()
+    {
+        $this->request->setStatementDescriptor('OMNIPAY');
+        $data = $this->request->getData();
+
+        $this->assertSame('OMNIPAY', $data['statement_descriptor']);
+    }
+
     public function testDataWithToken()
     {
         $this->request->setToken('xyz');


### PR DESCRIPTION
Optional parameter. `< > " '` characters are not allowed and are stripped out, see https://stripe.com/docs/api#create_charge
Let me know if you would prefer to throw an exception or something instead of just stripping them out.

Also included a test.