### PR TITLE
Fix for #30, only pass the customer reference if card data is not sup…

### DIFF
--- a/src/Message/AuthorizeRequest.php
+++ b/src/Message/AuthorizeRequest.php
@@ -153,17 +153,20 @@ class AuthorizeRequest extends AbstractRequest
 
         if ($this->getSource()) {
             $data['source'] = $this->getSource();
-        } elseif ($this->getCustomerReference()) {
-            $data['customer'] = $this->getCustomerReference();
-            if ($this->getCardReference()) {
-                $data['source'] = $this->getCardReference();
-            }
         } elseif ($this->getCardReference()) {
             $data['source'] = $this->getCardReference();
+            if ($this->getCustomerReference()) {
+                $data['customer'] = $this->getCustomerReference();
+            }
         } elseif ($this->getToken()) {
             $data['source'] = $this->getToken();
+            if ($this->getCustomerReference()) {
+                $data['customer'] = $this->getCustomerReference();
+            }
         } elseif ($this->getCard()) {
             $data['source'] = $this->getCardData();
+        } elseif ($this->getCustomerReference()) {
+            $data['customer'] = $this->getCustomerReference();
         } else {
             // one of cardReference, token, or card is required
             $this->validate('source');

--- a/tests/GatewayTest.php
+++ b/tests/GatewayTest.php
@@ -89,4 +89,28 @@ class GatewayTest extends GatewayTestCase
         $this->assertInstanceOf('Omnipay\Stripe\Message\DeleteCardRequest', $request);
         $this->assertSame('cus_1MZSEtqSghKx99', $request->getCardReference());
     }
+
+    public function testCreateCustomer()
+    {
+        $request = $this->gateway->createCustomer(array('description' => 'foo@foo.com'));
+
+        $this->assertInstanceOf('Omnipay\Stripe\Message\CreateCustomerRequest', $request);
+        $this->assertSame('foo@foo.com', $request->getDescription());
+    }
+
+    public function testUpdateCustomer()
+    {
+        $request = $this->gateway->updateCustomer(array('customerReference' => 'cus_1MZSEtqSghKx99'));
+
+        $this->assertInstanceOf('Omnipay\Stripe\Message\UpdateCustomerRequest', $request);
+        $this->assertSame('cus_1MZSEtqSghKx99', $request->getCustomerReference());
+    }
+
+    public function testDeleteCustomer()
+    {
+        $request = $this->gateway->deleteCustomer(array('customerReference' => 'cus_1MZSEtqSghKx99'));
+
+        $this->assertInstanceOf('Omnipay\Stripe\Message\DeleteCustomerRequest', $request);
+        $this->assertSame('cus_1MZSEtqSghKx99', $request->getCustomerReference());
+    }
 }

--- a/tests/Message/AuthorizeRequestTest.php
+++ b/tests/Message/AuthorizeRequestTest.php
@@ -45,6 +45,15 @@ class AuthorizeRequestTest extends TestCase
         $this->request->getData();
     }
 
+    public function testDataWithCustomerReference()
+    {
+        $this->request->setCard(null);
+        $this->request->setCustomerReference('abc');
+        $data = $this->request->getData();
+
+        $this->assertSame('abc', $data['customer']);
+    }
+
     public function testDataWithCardReference()
     {
         $this->request->setCustomerReference('abc');
@@ -55,11 +64,23 @@ class AuthorizeRequestTest extends TestCase
         $this->assertSame('xyz', $data['source']);
     }
 
+    public function testDataWithSourceAndDestination()
+    {
+        $this->request->setSource('abc');
+        $this->request->setDestination('xyz');
+        $data = $this->request->getData();
+
+        $this->assertSame('abc', $data['source']);
+        $this->assertSame('xyz', $data['destination']);
+    }
+
     public function testDataWithToken()
     {
+        $this->request->setCustomerReference('abc');
         $this->request->setToken('xyz');
         $data = $this->request->getData();
 
+        $this->assertSame('abc', $data['customer']);
         $this->assertSame('xyz', $data['source']);
     }
 

--- a/tests/Message/CreateCardRequestTest.php
+++ b/tests/Message/CreateCardRequestTest.php
@@ -38,6 +38,24 @@ class CreateCardRequestTest extends TestCase
         $this->assertSame('xyz', $data['source']);
     }
 
+    public function testDataWithCardReference()
+    {
+        $this->request->setCard(null);
+        $this->request->setCardReference('xyz');
+        $data = $this->request->getData();
+
+        $this->assertSame('xyz', $data['source']);
+    }
+
+    public function testDataWithSource()
+    {
+        $this->request->setCard(null);
+        $this->request->setSource('xyz');
+        $data = $this->request->getData();
+
+        $this->assertSame('xyz', $data['source']);
+    }
+
     public function testDataWithCard()
     {
         $card = $this->getValidCard();

--- a/tests/Message/PurchaseRequestTest.php
+++ b/tests/Message/PurchaseRequestTest.php
@@ -36,6 +36,18 @@ class PurchaseRequestTest extends TestCase
         $this->assertNull($response->getMessage());
     }
 
+    public function testSendWithSourceSuccess()
+    {
+        $this->setMockHttpResponse('PurchaseWithSourceSuccess.txt');
+        $response = $this->request->send();
+
+        $this->assertTrue($response->isSuccessful());
+        $this->assertFalse($response->isRedirect());
+        $this->assertSame('ch_1IU9gcUiNASROd', $response->getTransactionReference());
+        $this->assertSame('card_15WgqxIobxWFFmzdk5V9z3g9', $response->getCardReference());
+        $this->assertNull($response->getMessage());
+    }
+
     public function testSendError()
     {
         $this->setMockHttpResponse('PurchaseFailure.txt');

--- a/tests/Message/ResponseTest.php
+++ b/tests/Message/ResponseTest.php
@@ -18,6 +18,18 @@ class ResponseTest extends TestCase
         $this->assertNull($response->getMessage());
     }
 
+    public function testPurchaseWithSourceSuccess()
+    {
+        $httpResponse = $this->getMockHttpResponse('PurchaseWithSourceSuccess.txt');
+        $response = new Response($this->getMockRequest(), $httpResponse->json());
+
+        $this->assertTrue($response->isSuccessful());
+        $this->assertFalse($response->isRedirect());
+        $this->assertSame('ch_1IU9gcUiNASROd', $response->getTransactionReference());
+        $this->assertSame('card_15WgqxIobxWFFmzdk5V9z3g9', $response->getCardReference());
+        $this->assertNull($response->getMessage());
+    }
+
     public function testPurchaseFailure()
     {
         $httpResponse = $this->getMockHttpResponse('PurchaseFailure.txt');
@@ -99,6 +111,78 @@ class ResponseTest extends TestCase
         $this->assertFalse($response->isRedirect());
         $this->assertNull($response->getTransactionReference());
         $this->assertNull($response->getCustomerReference());
+        $this->assertSame('No such customer: cus_1MZeNih5LdKxDq', $response->getMessage());
+    }
+
+    public function testCreateCardSuccess()
+    {
+        $httpResponse = $this->getMockHttpResponse('CreateCardSuccess.txt');
+        $response = new Response($this->getMockRequest(), $httpResponse->json());
+
+        $this->assertTrue($response->isSuccessful());
+        $this->assertFalse($response->isRedirect());
+        $this->assertNull($response->getTransactionReference());
+        $this->assertSame('card_15WgqxIobxWFFmzdk5V9z3g9', $response->getCardReference());
+        $this->assertNull($response->getMessage());
+    }
+
+    public function testCreateCardFailure()
+    {
+        $httpResponse = $this->getMockHttpResponse('CreateCardFailure.txt');
+        $response = new Response($this->getMockRequest(), $httpResponse->json());
+
+        $this->assertFalse($response->isSuccessful());
+        $this->assertFalse($response->isRedirect());
+        $this->assertNull($response->getTransactionReference());
+        $this->assertNull($response->getCardReference());
+        $this->assertSame('You must provide an integer value for \'exp_year\'.', $response->getMessage());
+    }
+
+    public function testUpdateCardSuccess()
+    {
+        $httpResponse = $this->getMockHttpResponse('UpdateCardSuccess.txt');
+        $response = new Response($this->getMockRequest(), $httpResponse->json());
+
+        $this->assertTrue($response->isSuccessful());
+        $this->assertFalse($response->isRedirect());
+        $this->assertNull($response->getTransactionReference());
+        $this->assertSame('cus_1MZeNih5LdKxDq', $response->getCardReference());
+        $this->assertNull($response->getMessage());
+    }
+
+    public function testUpdateCardFailure()
+    {
+        $httpResponse = $this->getMockHttpResponse('UpdateCardFailure.txt');
+        $response = new Response($this->getMockRequest(), $httpResponse->json());
+
+        $this->assertFalse($response->isSuccessful());
+        $this->assertFalse($response->isRedirect());
+        $this->assertNull($response->getTransactionReference());
+        $this->assertNull($response->getCardReference());
+        $this->assertSame('No such customer: cus_1MZeNih5LdKxDq', $response->getMessage());
+    }
+
+    public function testDeleteCardSuccess()
+    {
+        $httpResponse = $this->getMockHttpResponse('DeleteCardSuccess.txt');
+        $response = new Response($this->getMockRequest(), $httpResponse->json());
+
+        $this->assertTrue($response->isSuccessful());
+        $this->assertFalse($response->isRedirect());
+        $this->assertNull($response->getTransactionReference());
+        $this->assertNull($response->getCardReference());
+        $this->assertNull($response->getMessage());
+    }
+
+    public function testDeleteCardFailure()
+    {
+        $httpResponse = $this->getMockHttpResponse('DeleteCardFailure.txt');
+        $response = new Response($this->getMockRequest(), $httpResponse->json());
+
+        $this->assertFalse($response->isSuccessful());
+        $this->assertFalse($response->isRedirect());
+        $this->assertNull($response->getTransactionReference());
+        $this->assertNull($response->getCardReference());
         $this->assertSame('No such customer: cus_1MZeNih5LdKxDq', $response->getMessage());
     }
 }

--- a/tests/Message/UpdateCardRequestTest.php
+++ b/tests/Message/UpdateCardRequestTest.php
@@ -26,6 +26,14 @@ class UpdateCardRequestTest extends TestCase
         $this->assertSame('xyz', $data['source']);
     }
 
+    public function testDataWithSource()
+    {
+        $this->request->setSource('xyz');
+        $data = $this->request->getData();
+
+        $this->assertSame('xyz', $data['source']);
+    }
+
     public function testDataWithCard()
     {
         $card = $this->getValidCard();

--- a/tests/Mock/PurchaseWithSourceSuccess.txt
+++ b/tests/Mock/PurchaseWithSourceSuccess.txt
@@ -1,0 +1,40 @@
+HTTP/1.1 200 OK
+Server: nginx
+Date: Fri, 15 Feb 2013 18:25:28 GMT
+Content-Type: application/json;charset=utf-8
+Content-Length: 995
+Connection: keep-alive
+Cache-Control: no-cache, no-store
+Access-Control-Allow-Credentials: true
+Access-Control-Max-Age: 300
+
+{
+  "id": "ch_1IU9gcUiNASROd",
+  "object": "charge",
+  "created": 1360952728,
+  "livemode": false,
+  "paid": true,
+  "amount": 1000,
+  "currency": "usd",
+  "refunded": false,
+  "fee": 59,
+  "fee_details": [
+    {
+      "amount": 59,
+      "currency": "usd",
+      "type": "stripe_fee",
+      "description": "Stripe processing fees",
+      "application": null,
+      "amount_refunded": 0
+    }
+  ],
+  "source": {
+    "id": "card_15WgqxIobxWFFmzdk5V9z3g9"
+  },
+  "failure_message": null,
+  "amount_refunded": 0,
+  "customer": null,
+  "invoice": null,
+  "description": "first purchase",
+  "dispute": null
+}


### PR DESCRIPTION

The previous logic passed the customer ID even if card data was supplied.  The new logic does not supply the customer ID if card data is supplied as follows:

* If an explicit source is supplied, pass that.
* If a card token is supplied, pass that, and if a customer ID is also supplied then also pass that.
* If card data is supplied then pass that, but do not pass the customer ID.
* Lastly, if a customer ID is supplied without a card token or card data then pass just the customer ID.

This fixes #30.