### PR TITLE
Added support for balance transaction

### DIFF
--- a/src/Gateway.php
+++ b/src/Gateway.php
@@ -52,6 +52,9 @@ use Omnipay\Stripe\Message\RefundRequest;
  *       echo "Purchase transaction was successful!\n";
  *       $sale_id = $response->getTransactionReference();
  *       echo "Transaction reference = " . $sale_id . "\n";
+ *
+ *       $balance_transaction_id = $response->getBalanceTransactionReference();
+ *       echo "Balance Transaction reference = " . $balance_transaction_id . "\n";
  *   }
  * </code>
  *
@@ -242,6 +245,15 @@ class Gateway extends AbstractGateway
     public function fetchTransaction(array $parameters = array())
     {
         return $this->createRequest('\Omnipay\Stripe\Message\FetchTransactionRequest', $parameters);
+    }
+
+    /**
+     * @param array $parameters
+     * @return \Omnipay\Stripe\Message\FetchBalanceTransactionRequest
+     */
+    public function fetchBalanceTransaction(array $parameters = array())
+    {
+        return $this->createRequest('\Omnipay\Stripe\Message\FetchBalanceTransactionRequest', $parameters);
     }
 
     //

--- a/src/Message/FetchBalanceTransactionRequest.php
+++ b/src/Message/FetchBalanceTransactionRequest.php
@@ -1,0 +1,68 @@
+<?php
+/**
+ * Stripe Fetch Transaction Request
+ */
+
+namespace Omnipay\Stripe\Message;
+
+/**
+ * Stripe Fetch Balance Request
+ *
+ * Example -- note this example assumes that the purchase has been successful
+ * and that the transaction balance ID returned from the purchase is held in $balanceTransactionId.
+ * See PurchaseRequest for the first part of this example transaction:
+ *
+ * <code>
+ *   // Fetch the balance to get information about the payment.
+ *   $balance = $gateway->fetchBalanceTransaction();
+ *   $balance->setBalanceTransactionReference($balance_transaction_id);
+ *   $response = $balance->send();
+ *   $data = $response->getData();
+ *   echo "Gateway fetchBalance response data == " . print_r($data, true) . "\n";
+ * </code>
+ *
+ * @see PurchaseRequest
+ * @see Omnipay\Stripe\Gateway
+ * @link https://stripe.com/docs/api#retrieve_balance_transaction
+ */
+class FetchBalanceTransactionRequest extends AbstractRequest
+{
+    /**
+     * Get the transaction balance reference
+     *
+     * @return string
+     */
+    public function getBalanceTransactionReference()
+    {
+        return $this->getParameter('balanceTransactionReference');
+    }
+
+    /**
+     * Set the transaction balance reference
+     *
+     * @return AbstractRequest provides a fluent interface.
+     */
+    public function setBalanceTransactionReference($value)
+    {
+        return $this->setParameter('balanceTransactionReference', $value);
+    }
+
+    public function getData()
+    {
+        $this->validate('balanceTransactionReference');
+
+        $data = array();
+
+        return $data;
+    }
+
+    public function getEndpoint()
+    {
+        return $this->endpoint.'/balance/history/'.$this->getBalanceTransactionReference();
+    }
+
+    public function getHttpMethod()
+    {
+        return 'GET';
+    }
+}

--- a/src/Message/Response.php
+++ b/src/Message/Response.php
@@ -44,6 +44,26 @@ class Response extends AbstractResponse
     }
 
     /**
+     * Get the balance transaction reference.
+     *
+     * @return string|null
+     */
+    public function getBalanceTransactionReference()
+    {
+        if (isset($this->data['object']) && 'charge' === $this->data['object']) {
+            return $this->data['balance_transaction'];
+        }
+        if (isset($this->data['object']) && 'balance_transaction' === $this->data['object']) {
+            return $this->data['id'];
+        }
+        if (isset($this->data['error']) && isset($this->data['error']['charge'])) {
+            return $this->data['error']['charge'];
+        }
+
+        return null;
+    }
+
+    /**
      * Get a customer reference, for createCustomer requests.
      *
      * @return string|null

--- a/tests/Message/FetchBalanceTransactionTest.php
+++ b/tests/Message/FetchBalanceTransactionTest.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace Omnipay\Stripe\Message;
+
+use Omnipay\Tests\TestCase;
+
+class FetchBalanceTransactionRequestTest extends TestCase
+{
+    public function setUp()
+    {
+        $this->request = new FetchBalanceTransactionRequest($this->getHttpClient(), $this->getHttpRequest());
+        $this->request->setBalanceTransactionReference('txn_1044bu4CmsDZ3Zk6BGg97VUU');
+    }
+
+    public function testEndpoint()
+    {
+        $this->assertSame('https://api.stripe.com/v1/balance/history/txn_1044bu4CmsDZ3Zk6BGg97VUU', $this->request->getEndpoint());
+    }
+
+    public function testSendSuccess()
+    {
+        $this->setMockHttpResponse('FetchBalanceTransactionSuccess.txt');
+        $response = $this->request->send();
+
+        $this->assertTrue($response->isSuccessful());
+        $this->assertFalse($response->isRedirect());
+        $this->assertSame('txn_1044bu4CmsDZ3Zk6BGg97VUU', $response->getBalanceTransactionReference());
+        $this->assertNull($response->getCardReference());
+        $this->assertNull($response->getMessage());
+    }
+
+    public function testSendError()
+    {
+        $this->setMockHttpResponse('FetchBalanceTransactionFailure.txt');
+        $response = $this->request->send();
+
+        $this->assertFalse($response->isSuccessful());
+        $this->assertFalse($response->isRedirect());
+        $this->assertNull($response->getBalanceTransactionReference());
+        $this->assertNull($response->getCardReference());
+        $this->assertSame('No such balance: txn_1044bu4CmsDZ3Zk6BGg97VUUfake', $response->getMessage());
+    }
+}

--- a/tests/Mock/FetchBalanceTransactionFailure.txt
+++ b/tests/Mock/FetchBalanceTransactionFailure.txt
@@ -1,0 +1,17 @@
+HTTP/1.1 404 Not Found 
+Server: nginx 
+Date: Wed, 24 Jul 2013 13:40:31 GMT 
+Content-Type: application/json;charset=utf-8 
+Content-Length: 132 
+Connection: keep-alive 
+Access-Control-Allow-Credentials: true 
+Access-Control-Max-Age: 300 
+Cache-Control: no-cache, no-store 
+
+{ 
+	"error": { 
+		"type": "invalid_request_error", 
+		"message": "No such balance: txn_1044bu4CmsDZ3Zk6BGg97VUUfake", 
+		"param": "id" 
+	} 
+}

--- a/tests/Mock/FetchBalanceTransactionSuccess.txt
+++ b/tests/Mock/FetchBalanceTransactionSuccess.txt
@@ -1,0 +1,49 @@
+HTTP/1.1 200 OK 
+Server: nginx 
+Date: Wed, 24 Jul 2013 07:14:02 GMT 
+Content-Type: application/json;charset=utf-8 
+Content-Length: 1092 
+Connection: keep-alive 
+Access-Control-Allow-Credentials: true 
+Access-Control-Max-Age: 300 
+Cache-Control: no-cache, no-store 
+
+{
+  "id": "txn_1044bu4CmsDZ3Zk6BGg97VUU",
+  "object": "balance_transaction",
+  "amount": 4013,
+  "available_on": 1401235200,
+  "created": 1400651717,
+  "currency": "eur",
+  "description": "Test #4",
+  "fee": 226,
+  "fee_details": [
+    {
+      "amount": 80,
+      "application": null,
+      "currency": "chf",
+      "description": "Stripe currency conversion fee",
+      "type": "stripe_fee"
+    },
+    {
+      "amount": 146,
+      "application": null,
+      "currency": "chf",
+      "description": "Stripe processing fees",
+      "type": "stripe_fee"
+    }
+  ],
+  "net": 3787,
+  "source": "ch_1044bu4CmsDZ3Zk6HkSkVsxd",
+  "sourced_transfers": {
+    "object": "list",
+    "data": [
+
+    ],
+    "has_more": false,
+    "total_count": 0,
+    "url": "/v1/transfers?source_transaction=ch_1044bu4CmsDZ3Zk6HkSkVsxd"
+  },
+  "status": "available",
+  "type": "charge"
+}


### PR DESCRIPTION
To get balance details like the net amount or the fee, Stripe has a [balance endpoint](https://stripe.com/docs/api/curl#balance). This pull request adds the necessary functions to get a balance of a transaction. The endpoint is described here https://stripe.com/docs/api/curl#retrieve_balance_transaction.