### PR TITLE
Send cardReference as customer instead of source

### DIFF
--- a/src/Message/AuthorizeRequest.php
+++ b/src/Message/AuthorizeRequest.php
@@ -174,7 +174,7 @@ class AuthorizeRequest extends AbstractRequest
                 $data['source'] = $this->getCardReference();
             }
         } elseif ($this->getCardReference()) {
-            $data['source'] = $this->getCardReference();
+            $data['customer'] = $this->getCardReference();
         } elseif ($this->getToken()) {
             $data['source'] = $this->getToken();
         } elseif ($this->getCard()) {


### PR DESCRIPTION
The card Id should be sent as customer not source.