### PR TITLE
Add email to AbstractRequest

### DIFF
--- a/src/Message/AbstractRequest.php
+++ b/src/Message/AbstractRequest.php
@@ -195,6 +195,7 @@ abstract class AbstractRequest extends \Omnipay\Common\Message\AbstractRequest
         $data['address_zip'] = $card->getPostcode();
         $data['address_state'] = $card->getState();
         $data['address_country'] = $card->getCountry();
+        $data['email']           = $card->getEmail();
 
         return $data;
     }


### PR DESCRIPTION
Hello
In order to be able to see customer's email, in the request data array a $data['email'] is added.
Please review this change if it is not  a problem. We use Omnipay not only for Stripe, otherwise would be very easy to add it just to the code and use $response->sendData($data).
Thank you in advance 