### PR TITLE
Adds support for `receipt_email` option to AuthorizeRequest

### DIFF
--- a/src/Message/AuthorizeRequest.php
+++ b/src/Message/AuthorizeRequest.php
@@ -146,6 +146,25 @@ class AuthorizeRequest extends AbstractRequest
         return $this->setParameter('statementDescriptor', $value);
     }
 
+    /**
+     * @return mixed
+     */
+    public function getReceiptEmail()
+    {
+        return $this->getParameter('receipt_email');
+    }
+
+    /**
+     * @param mixed $email
+     * @return $this
+     */
+    public function setReceiptEmail($email)
+    {
+        $this->setParameter('receipt_email', $email);
+
+        return $this;
+    }
+
     public function getData()
     {
         $this->validate('amount', 'currency');
@@ -167,6 +186,10 @@ class AuthorizeRequest extends AbstractRequest
 
         if ($this->getApplicationFee()) {
             $data['application_fee'] = $this->getApplicationFeeInteger();
+        }
+
+        if ($this->getReceiptEmail()) {
+            $data['receipt_email'] = $this->getReceiptEmail();
         }
 
         if ($this->getSource()) {


### PR DESCRIPTION
As suggested by #32.

This enables the user to pass through Stripe's `receipt_email` option when creating a charge, but does not change the default behaviour if the option is not set (ref declined PR #5).

https://stripe.com/docs/api#create_charge-receipt_email