### PR TITLE
offer add AbstractRequest::getRequestId()

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-1# Omnipay: Stripe
+# Omnipay: Stripe
 
 **Stripe driver for the Omnipay PHP payment processing library**
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Omnipay: Stripe
+1# Omnipay: Stripe
 
 **Stripe driver for the Omnipay PHP payment processing library**
 

--- a/src/Message/AbstractRequest.php
+++ b/src/Message/AbstractRequest.php
@@ -42,13 +42,6 @@ abstract class AbstractRequest extends \Omnipay\Common\Message\AbstractRequest
     protected $endpoint = 'https://api.stripe.com/v1';
 
     /**
-     * Request id
-     *
-     * @var string URL
-     */
-    protected $requestId = null;
-
-    /**
      * Get the gateway API Key.
      *
      * @return string
@@ -152,22 +145,15 @@ abstract class AbstractRequest extends \Omnipay\Common\Message\AbstractRequest
         $httpResponse = $httpRequest
             ->setHeader('Authorization', 'Basic '.base64_encode($this->getApiKey().':'))
             ->send();
-
+        
+        $this->response = new Response($this, $httpResponse->json());
+        
         if ($httpResponse->hasHeader('Request-Id')) {
-            $this->requestId = (string) $httpResponse->getHeader('Request-Id');
+            $this->response->setRequestId((string) $httpResponse->getHeader('Request-Id'));
         }
 
-        return $this->response = new Response($this, $httpResponse->json());
+        return $this->response;
     }
-
-    /**
-     * @return string
-     */
-    public function getRequestId()
-    {
-        return $this->requestId;
-    }
-
 
     /**
      * @return mixed

--- a/src/Message/AbstractRequest.php
+++ b/src/Message/AbstractRequest.php
@@ -42,6 +42,13 @@ abstract class AbstractRequest extends \Omnipay\Common\Message\AbstractRequest
     protected $endpoint = 'https://api.stripe.com/v1';
 
     /**
+     * Request id
+     *
+     * @var string URL
+     */
+    protected $requestId = null;
+
+    /**
      * Get the gateway API Key.
      *
      * @return string
@@ -146,8 +153,21 @@ abstract class AbstractRequest extends \Omnipay\Common\Message\AbstractRequest
             ->setHeader('Authorization', 'Basic '.base64_encode($this->getApiKey().':'))
             ->send();
 
+        if ($httpResponse->hasHeader('Request-Id')) {
+            $this->requestId = (string) $httpResponse->getHeader('Request-Id');
+        }
+
         return $this->response = new Response($this, $httpResponse->json());
     }
+
+    /**
+     * @return string
+     */
+    public function getRequestId()
+    {
+        return $this->requestId;
+    }
+
 
     /**
      * @return mixed
@@ -166,6 +186,7 @@ abstract class AbstractRequest extends \Omnipay\Common\Message\AbstractRequest
     {
         return $this->setParameter('source', $value);
     }
+
 
     /**
      * Get the card data.

--- a/src/Message/Response.php
+++ b/src/Message/Response.php
@@ -17,6 +17,13 @@ use Omnipay\Common\Message\AbstractResponse;
 class Response extends AbstractResponse
 {
     /**
+     * Request id
+     *
+     * @var string URL
+     */
+    protected $requestId = null;
+    
+    /**
      * Is the transaction successful?
      *
      * @return bool
@@ -300,5 +307,23 @@ class Response extends AbstractResponse
         }
 
         return null;
+    }
+    
+    /**
+     * @return string
+     */
+    public function getRequestId()
+    {
+        return $this->requestId;
+    }
+
+    /**
+     * Set request id
+     *
+     * @return AbstractRequest provides a fluent interface.
+     */
+    public function setRequestId($requestId)
+    {
+        $this->requestId = $requestId;
     }
 }

--- a/tests/Message/AuthorizeRequestTest.php
+++ b/tests/Message/AuthorizeRequestTest.php
@@ -110,7 +110,7 @@ class AuthorizeRequestTest extends TestCase
         $this->assertFalse($response->isRedirect());
         $this->assertSame('ch_1IU9gcUiNASROd', $response->getTransactionReference());
         $this->assertSame('card_16n3EU2baUhq7QENSrstkoN0', $response->getCardReference());
-        $this->assertSame('req_8PDHeZazN2LwML', $response->getRequest()->getRequestId());
+        $this->assertSame('req_8PDHeZazN2LwML', $response->getRequestId());
         $this->assertNull($response->getMessage());
     }
 

--- a/tests/Message/AuthorizeRequestTest.php
+++ b/tests/Message/AuthorizeRequestTest.php
@@ -110,6 +110,7 @@ class AuthorizeRequestTest extends TestCase
         $this->assertFalse($response->isRedirect());
         $this->assertSame('ch_1IU9gcUiNASROd', $response->getTransactionReference());
         $this->assertSame('card_16n3EU2baUhq7QENSrstkoN0', $response->getCardReference());
+        $this->assertSame('req_8PDHeZazN2LwML', $response->getRequest()->getRequestId());
         $this->assertNull($response->getMessage());
     }
 

--- a/tests/Mock/PurchaseSuccess.txt
+++ b/tests/Mock/PurchaseSuccess.txt
@@ -5,6 +5,7 @@ Content-Type: application/json;charset=utf-8
 Content-Length: 995
 Connection: keep-alive
 Cache-Control: no-cache, no-store
+Request-Id: req_8PDHeZazN2LwML
 Access-Control-Allow-Credentials: true
 Access-Control-Max-Age: 300
 


### PR DESCRIPTION
Each stripe response have id. It included in header. See  tripe documentation (https://stripe.com/docs/api#request_ids). I offer add method AbstractRequest::getRequestId() for get it

https://github.com/thephpleague/omnipay-stripe/commit/604c761ac03dc3c0bedc03a85fa79c3b9106ba4b