### PR TITLE
Ability to cancel subscriptions at the end of its period

### DIFF
--- a/src/Message/CancelSubscriptionRequest.php
+++ b/src/Message/CancelSubscriptionRequest.php
@@ -61,9 +61,14 @@ class CancelSubscriptionRequest extends AbstractRequest
     {
         $this->validate('customerReference', 'subscriptionReference');
 
-        $data = array(
-            'at_period_end' => $this->getAtPeriodEnd()
-        );
+        $data = array();
+
+        // NOTE: Boolean must be passed as string
+        // Otherwise it will be converted as numeric 1 or 2
+        // Causing an error with the API
+        if ($this->getAtPeriodEnd()) {
+            $data['at_period_end'] = 'true';
+        }
 
         return $data;
     }

--- a/src/Message/CancelSubscriptionRequest.php
+++ b/src/Message/CancelSubscriptionRequest.php
@@ -26,6 +26,8 @@ class CancelSubscriptionRequest extends AbstractRequest
     /**
      * Set the set subscription reference.
      *
+     * @param string $value
+     *
      * @return CancelSubscriptionRequest provides a fluent interface.
      */
     public function setSubscriptionReference($value)
@@ -33,11 +35,35 @@ class CancelSubscriptionRequest extends AbstractRequest
         return $this->setParameter('subscriptionReference', $value);
     }
 
+    /**
+     * Set whether or not to cancel the subscription at period end.
+     *
+     * @param bool $value
+     *
+     * @return CancelSubscriptionRequest provides a fluent interface.
+     */
+    public function setAtPeriodEnd($value)
+    {
+        return $this->setParameter('atPeriodEnd', $value);
+    }
+
+    /**
+     * Get whether or not to cancel the subscription at period end.
+     *
+     * @return bool
+     */
+    public function getAtPeriodEnd()
+    {
+        return $this->getParameter('atPeriodEnd');
+    }
+
     public function getData()
     {
         $this->validate('customerReference', 'subscriptionReference');
 
-        $data = array();
+        $data = array(
+            'at_period_end' => $this->getAtPeriodEnd()
+        );
 
         return $data;
     }

--- a/src/Message/CancelSubscriptionRequest.php
+++ b/src/Message/CancelSubscriptionRequest.php
@@ -64,7 +64,7 @@ class CancelSubscriptionRequest extends AbstractRequest
         $data = array();
 
         // NOTE: Boolean must be passed as string
-        // Otherwise it will be converted as numeric 1 or 2
+        // Otherwise it will be converted to numeric 0 or 1
         // Causing an error with the API
         if ($this->getAtPeriodEnd()) {
             $data['at_period_end'] = 'true';

--- a/tests/Message/CancelSubscriptionRequestTest.php
+++ b/tests/Message/CancelSubscriptionRequestTest.php
@@ -11,11 +11,16 @@ class CancelSubscriptionRequestTest extends TestCase
         $this->request = new CancelSubscriptionRequest($this->getHttpClient(), $this->getHttpRequest());
         $this->request->setCustomerReference('cus_7lfqk3Om3t4xSU');
         $this->request->setSubscriptionReference('sub_7mU0FokE8GQZFW');
+        $this->request->setAtPeriodEnd(true);
     }
 
     public function testEndpoint()
     {
         $this->assertSame('https://api.stripe.com/v1/customers/cus_7lfqk3Om3t4xSU/subscriptions/sub_7mU0FokE8GQZFW', $this->request->getEndpoint());
+        $this->assertSame(true, $this->request->getAtPeriodEnd());
+
+        $data = $this->request->getData();
+        $this->assertSame('true', $data['at_period_end']);
     }
 
     public function testSendSuccess()


### PR DESCRIPTION
Add the option to set whether or not cancel the subscription at the end of the subscription period using the option `at_period_end`. See https://stripe.com/docs/api/php#update_subscription-at_period_end