### PR TITLE
Incorrect data sent when updating card

### DIFF
--- a/src/Message/UpdateCardRequest.php
+++ b/src/Message/UpdateCardRequest.php
@@ -27,19 +27,11 @@ class UpdateCardRequest extends AbstractRequest
         $this->validate('cardReference');
         $this->validate('customerReference');
 
-        $data = array();
-        $data['description'] = $this->getDescription();
-
-        if ($this->getSource()) {
-            $data['source'] = $this->getSource();
-        } elseif ($this->getToken()) {
-            $data['source'] = $this->getToken();
-        } elseif ($this->getCard()) {
-            $data['source'] = $this->getCardData();
-            $data['email'] = $this->getCard()->getEmail();
+        if ($this->getCard()) {
+            return $this->getCardData();
+        } else {
+            return array();
         }
-
-        return $data;
     }
 
     public function getEndpoint()

--- a/tests/Message/UpdateCardRequestTest.php
+++ b/tests/Message/UpdateCardRequestTest.php
@@ -18,30 +18,14 @@ class UpdateCardRequestTest extends TestCase
         $this->assertSame('https://api.stripe.com/v1/customers/cus_1MZSEtqSghKx99/cards/card_15Wg7vIobxWFFmzdvC5fVY67', $this->request->getEndpoint());
     }
 
-    public function testDataWithToken()
-    {
-        $this->request->setToken('xyz');
-        $data = $this->request->getData();
-
-        $this->assertSame('xyz', $data['source']);
-    }
-
-    public function testDataWithSource()
-    {
-        $this->request->setSource('xyz');
-        $data = $this->request->getData();
-
-        $this->assertSame('xyz', $data['source']);
-    }
-
     public function testDataWithCard()
     {
         $card = $this->getValidCard();
         $this->request->setCard($card);
         $data = $this->request->getData();
 
-        $this->assertSame($card['billingAddress1'], $data['source']['address_line1']);
-        $this->assertSame($card['number'], $data['source']['number']);
+        $this->assertSame($card['billingAddress1'], $data['address_line1']);
+        $this->assertSame($card['number'], $data['number']);
     }
 
     public function testSendSuccess()


### PR DESCRIPTION
The endpoint for updating card doesn't expect `source`, `description` or `email` as arguments. 
It will respond with an error like `Received unknown parameter: description`.

According to https://stripe.com/docs/api/php#update_card the arguments should be as following, what `UpdateCardRequest::getCardData()` also returns.

- id (required)
- address_city
- address_country
- address_line1
- address_line2
- address_state
- address_zip
- exp_month
- exp_year
- metadata
- name