### PR TITLE
Allow 'source' parameter when creating a customer

### DIFF
--- a/src/Message/CreateCustomerRequest.php
+++ b/src/Message/CreateCustomerRequest.php
@@ -104,6 +104,16 @@ class CreateCustomerRequest extends AbstractRequest
         return $this->setParameter('email', $value);
     }
 
+    public function getSource()
+    {
+        return $this->getParameter('source');
+    }
+
+    public function setSource($value)
+    {
+        $this->setParameter('source', $value);
+    }
+
     public function getData()
     {
         $data = array();
@@ -111,7 +121,7 @@ class CreateCustomerRequest extends AbstractRequest
 
         if ($this->getToken()) {
             $data['card'] = $this->getToken();
-            
+
             if ($this->getEmail()) {
                 $data['email'] = $this->getEmail();
             }
@@ -124,6 +134,10 @@ class CreateCustomerRequest extends AbstractRequest
 
         if ($this->getMetadata()) {
             $data['metadata'] = $this->getMetadata();
+        }
+
+        if ($this->getSource()) {
+            $data['source'] = $this->getSource();
         }
 
         return $data;


### PR DESCRIPTION
The Stripe API accepts a 'source' parameter when creating a new Customer. This source can be the token generated by stripe form.

This pull request adds this parameter to the API call.