### PR TITLE
Add Stripe Connect charges/transfer support (fixes #33, #70, #78)

### DIFF
--- a/src/Gateway.php
+++ b/src/Gateway.php
@@ -277,6 +277,101 @@ class Gateway extends AbstractGateway
         return $this->createRequest('\Omnipay\Stripe\Message\FetchBalanceTransactionRequest', $parameters);
     }
 
+
+    //
+    // Transfers
+    // @link https://stripe.com/docs/api#transfers
+    //
+
+
+    /**
+     * Transfer Request.
+     *
+     * To send funds from your Stripe account to a connected account, you create
+     * a new transfer object. Your Stripe balance must be able to cover the
+     * transfer amount, or you'll receive an "Insufficient Funds" error.
+     *
+     * @param array $parameters
+     *
+     * @return \Omnipay\Common\Message\AbstractRequest
+     */
+    public function transfer(array $parameters = array())
+    {
+        return $this->createRequest('\Omnipay\Stripe\Message\Transfers\CreateTransferRequest', $parameters);
+    }
+
+    /**
+     * @param array $parameters
+     *
+     * @return \Omnipay\Common\Message\AbstractRequest
+     */
+    public function fetchTransfer(array $parameters = array())
+    {
+        return $this->createRequest('\Omnipay\Stripe\Message\Transfers\FetchTransferRequest', $parameters);
+    }
+
+    /**
+     * @param array $parameters
+     *
+     * @return \Omnipay\Common\Message\AbstractRequest
+     */
+    public function updateTransfer(array $parameters = array())
+    {
+        return $this->createRequest('\Omnipay\Stripe\Message\Transfers\UpdateTransferRequest', $parameters);
+    }
+
+    /**
+     * List Transfers
+     *
+     * @param array $parameters
+     *
+     * @return \Omnipay\Common\Message\AbstractRequest|\Omnipay\Stripe\Message\Transfers\ListTransfersRequest
+     */
+    public function listTransfers(array $parameters = array())
+    {
+        return $this->createRequest('\Omnipay\Stripe\Message\Transfers\ListTransfersRequest', $parameters);
+    }
+
+    /**
+     * @param array $parameters
+     *
+     * @return \Omnipay\Common\Message\AbstractRequest
+     */
+    public function reverseTransfer(array $parameters = array())
+    {
+        return $this->createRequest('\Omnipay\Stripe\Message\Transfers\CreateTransferReversalRequest', $parameters);
+    }
+
+    /**
+     * @param array $parameters
+     *
+     * @return \Omnipay\Common\Message\AbstractRequest
+     */
+    public function fetchTransferReversal(array $parameters = array())
+    {
+        return $this->createRequest('\Omnipay\Stripe\Message\Transfers\FetchTransferReversalRequest', $parameters);
+    }
+
+    /**
+     * @param array $parameters
+     *
+     * @return \Omnipay\Common\Message\AbstractRequest
+     */
+    public function updateTransferReversal(array $parameters = array())
+    {
+        return $this->createRequest('\Omnipay\Stripe\Message\Transfers\UpdateTransferReversalRequest', $parameters);
+    }
+
+    /**
+     * @param array $parameters
+     *
+     * @return \Omnipay\Common\Message\AbstractRequest
+     */
+    public function listTransferReversals(array $parameters = array())
+    {
+        return $this->createRequest('\Omnipay\Stripe\Message\Transfers\ListTransferReversalsRequest', $parameters);
+    }
+
     //
     // Cards
     // @link https://stripe.com/docs/api#cards

--- a/src/Message/AbstractRequest.php
+++ b/src/Message/AbstractRequest.php
@@ -3,7 +3,10 @@
 /**
  * Stripe Abstract Request.
  */
+
 namespace Omnipay\Stripe\Message;
+
+use Omnipay\Common\Message\ResponseInterface;
 
 /**
  * Stripe Abstract Request.
@@ -29,8 +32,6 @@ namespace Omnipay\Stripe\Message;
  *
  * @see \Omnipay\Stripe\Gateway
  * @link https://stripe.com/docs/api
- *
- * @method \Omnipay\Stripe\Message\Response send()
  */
 abstract class AbstractRequest extends \Omnipay\Common\Message\AbstractRequest
 {
@@ -110,6 +111,26 @@ abstract class AbstractRequest extends \Omnipay\Common\Message\AbstractRequest
         return $this->setParameter('metadata', $value);
     }
 
+    /**
+     * Connect only
+     *
+     * @return mixed
+     */
+    public function getConnectedStripeAccountHeader()
+    {
+        return $this->getParameter('connectedStripeAccount');
+    }
+
+    /**
+     * @param string $value
+     *
+     * @return \Omnipay\Common\Message\AbstractRequest
+     */
+    public function setConnectedStripeAccountHeader($value)
+    {
+        return $this->setParameter('connectedStripeAccount', $value);
+    }
+
     abstract public function getEndpoint();
 
     /**
@@ -124,15 +145,51 @@ abstract class AbstractRequest extends \Omnipay\Common\Message\AbstractRequest
         return 'POST';
     }
 
-    public function sendData($data)
+    /**
+     * @return array
+     */
+    public function getHeaders()
+    {
+        $data = [];
+
+        if ($this->getConnectedStripeAccountHeader()) {
+            $data['Stripe-Account'] = $this->getConnectedStripeAccountHeader();
+        }
+
+        return [];
+    }
+
+    /**
+     * Send the request
+     *
+     * @return ResponseInterface
+     */
+    public function send()
+    {
+        $data    = $this->getData();
+        $headers = array_merge(
+            $this->getHeaders(),
+            ['Authorization' => 'Basic ' . base64_encode($this->getApiKey() . ':')]
+        );
+
+        return $this->sendData($data, $headers);
+    }
+
+    /**
+     * @param       $data
+     * @param array $headers
+     *
+     * @return \Guzzle\Http\Message\RequestInterface
+     */
+    private function createClientRequest($data, $headers = null)
     {
         // Stripe only accepts TLS >= v1.2, so make sure Curl is told
-        $config = $this->httpClient->getConfig();
-        $curlOptions = $config->get('curl.options');
+        $config                          = $this->httpClient->getConfig();
+        $curlOptions                     = $config->get('curl.options');
         $curlOptions[CURLOPT_SSLVERSION] = 6;
         $config->set('curl.options', $curlOptions);
         $this->httpClient->setConfig($config);
-        
+
         // don't throw exceptions for 4xx errors
         $this->httpClient->getEventDispatcher()->addListener(
             'request.error',
@@ -146,15 +203,20 @@ abstract class AbstractRequest extends \Omnipay\Common\Message\AbstractRequest
         $httpRequest = $this->httpClient->createRequest(
             $this->getHttpMethod(),
             $this->getEndpoint(),
-            null,
+            $headers,
             $data
         );
-        $httpResponse = $httpRequest
-            ->setHeader('Authorization', 'Basic '.base64_encode($this->getApiKey().':'))
-            ->send();
-        
+
+        return $httpRequest;
+    }
+
+    public function sendData($data, $headers = [])
+    {
+        $httpRequest  = $this->createClientRequest($data, $headers);
+        $httpResponse = $httpRequest->send();
+
         $this->response = new Response($this, $httpResponse->json());
-        
+
         if ($httpResponse->hasHeader('Request-Id')) {
             $this->response->setRequestId((string) $httpResponse->getHeader('Request-Id'));
         }
@@ -179,7 +241,6 @@ abstract class AbstractRequest extends \Omnipay\Common\Message\AbstractRequest
     {
         return $this->setParameter('source', $value);
     }
-
 
     /**
      * Get the card data.

--- a/src/Message/AbstractRequest.php
+++ b/src/Message/AbstractRequest.php
@@ -170,7 +170,7 @@ abstract class AbstractRequest extends \Omnipay\Common\Message\AbstractRequest
      */
     public function getHeaders()
     {
-        $headers = [];
+        $headers = array();
 
         if ($this->getConnectedStripeAccountHeader()) {
             $headers['Stripe-Account'] = $this->getConnectedStripeAccountHeader();
@@ -193,7 +193,7 @@ abstract class AbstractRequest extends \Omnipay\Common\Message\AbstractRequest
         $data    = $this->getData();
         $headers = array_merge(
             $this->getHeaders(),
-            ['Authorization' => 'Basic ' . base64_encode($this->getApiKey() . ':')]
+            array('Authorization' => 'Basic ' . base64_encode($this->getApiKey() . ':'))
         );
 
         return $this->sendData($data, $headers);
@@ -205,7 +205,7 @@ abstract class AbstractRequest extends \Omnipay\Common\Message\AbstractRequest
      *
      * @return \Guzzle\Http\Message\RequestInterface
      */
-    protected function createClientRequest($data, $headers = null)
+    protected function createClientRequest($data, array $headers = null)
     {
         // Stripe only accepts TLS >= v1.2, so make sure Curl is told
         $config                          = $this->httpClient->getConfig();
@@ -234,7 +234,7 @@ abstract class AbstractRequest extends \Omnipay\Common\Message\AbstractRequest
         return $httpRequest;
     }
 
-    public function sendData($data, $headers = [])
+    public function sendData($data, array $headers = null)
     {
         $httpRequest  = $this->createClientRequest($data, $headers);
         $httpResponse = $httpRequest->send();

--- a/src/Message/AbstractRequest.php
+++ b/src/Message/AbstractRequest.php
@@ -131,6 +131,26 @@ abstract class AbstractRequest extends \Omnipay\Common\Message\AbstractRequest
         return $this->setParameter('connectedStripeAccount', $value);
     }
 
+    /**
+     * Connect only
+     *
+     * @return mixed
+     */
+    public function getIdempotencyKeyHeader()
+    {
+        return $this->getParameter('idempotencyKey');
+    }
+
+    /**
+     * @param string $value
+     *
+     * @return \Omnipay\Common\Message\AbstractRequest
+     */
+    public function setIdempotencyKeyHeader($value)
+    {
+        return $this->setParameter('idempotencyKey', $value);
+    }
+
     abstract public function getEndpoint();
 
     /**
@@ -154,6 +174,10 @@ abstract class AbstractRequest extends \Omnipay\Common\Message\AbstractRequest
 
         if ($this->getConnectedStripeAccountHeader()) {
             $data['Stripe-Account'] = $this->getConnectedStripeAccountHeader();
+        }
+
+        if ($this->getIdempotencyKeyHeader()) {
+            $data['Idempotency-Key'] = $this->getIdempotencyKeyHeader();
         }
 
         return [];

--- a/src/Message/AbstractRequest.php
+++ b/src/Message/AbstractRequest.php
@@ -170,17 +170,17 @@ abstract class AbstractRequest extends \Omnipay\Common\Message\AbstractRequest
      */
     public function getHeaders()
     {
-        $data = [];
+        $headers = [];
 
         if ($this->getConnectedStripeAccountHeader()) {
-            $data['Stripe-Account'] = $this->getConnectedStripeAccountHeader();
+            $headers['Stripe-Account'] = $this->getConnectedStripeAccountHeader();
         }
 
         if ($this->getIdempotencyKeyHeader()) {
-            $data['Idempotency-Key'] = $this->getIdempotencyKeyHeader();
+            $headers['Idempotency-Key'] = $this->getIdempotencyKeyHeader();
         }
 
-        return [];
+        return $headers;
     }
 
     /**
@@ -205,7 +205,7 @@ abstract class AbstractRequest extends \Omnipay\Common\Message\AbstractRequest
      *
      * @return \Guzzle\Http\Message\RequestInterface
      */
-    private function createClientRequest($data, $headers = null)
+    protected function createClientRequest($data, $headers = null)
     {
         // Stripe only accepts TLS >= v1.2, so make sure Curl is told
         $config                          = $this->httpClient->getConfig();

--- a/src/Message/AuthorizeRequest.php
+++ b/src/Message/AuthorizeRequest.php
@@ -91,7 +91,7 @@ class AuthorizeRequest extends AbstractRequest
     }
 
     /**
-     * @return mixedgi
+     * @return mixed
      */
     public function getSource()
     {
@@ -106,6 +106,46 @@ class AuthorizeRequest extends AbstractRequest
     public function setSource($value)
     {
         return $this->setParameter('source', $value);
+    }
+
+    /**
+     * Connect only
+     *
+     * @return mixed
+     */
+    public function getTransferGroup()
+    {
+        return $this->getParameter('transferGroup');
+    }
+
+    /**
+     * @param string $value
+     *
+     * @return AbstractRequest provides a fluent interface.
+     */
+    public function setTransferGroup($value)
+    {
+        return $this->setParameter('transferGroup', $value);
+    }
+
+    /**
+     * Connect only
+     *
+     * @return mixed
+     */
+    public function getOnBehalfOf()
+    {
+        return $this->getParameter('onBehalfOf');
+    }
+
+    /**
+     * @param string $value
+     *
+     * @return AbstractRequest provides a fluent interface.
+     */
+    public function setOnBehalfOf($value)
+    {
+        return $this->setParameter('onBehalfOf', $value);
     }
 
     /**
@@ -184,8 +224,16 @@ class AuthorizeRequest extends AbstractRequest
             $data['destination'] = $this->getDestination();
         }
 
+        if ($this->getOnBehalfOf()) {
+            $data['on_behalf_of'] = $this->getOnBehalfOf();
+        }
+
         if ($this->getApplicationFee()) {
             $data['application_fee'] = $this->getApplicationFeeInteger();
+        }
+
+        if ($this->getTransferGroup()) {
+            $data['transfer_group'] = $this->getTransferGroup();
         }
 
         if ($this->getReceiptEmail()) {

--- a/src/Message/DeleteInvoiceItemRequest.php
+++ b/src/Message/DeleteInvoiceItemRequest.php
@@ -25,7 +25,7 @@ class DeleteInvoiceItemRequest extends AbstractRequest
     /**
      * Set the set invoice-item reference.
      *
-     * @return FetchInvoiceItemLinesRequest provides a fluent interface.
+     * @return DeleteInvoiceItemRequest provides a fluent interface.
      */
     public function setInvoiceItemReference($value)
     {

--- a/src/Message/FetchChargeRequest.php
+++ b/src/Message/FetchChargeRequest.php
@@ -7,7 +7,7 @@ namespace Omnipay\Stripe\Message;
 
 /**
  * Stripe Fetch Charge Request.
- * 
+ *
  * @deprecated 2.3.3:3.0.0 functionality provided by \Omnipay\Stripe\Message\FetchTransactionRequest
  * @see \Omnipay\Stripe\Message\FetchTransactionRequest
  * @link https://stripe.com/docs/api#retrieve_charge

--- a/src/Message/FetchInvoiceItemRequest.php
+++ b/src/Message/FetchInvoiceItemRequest.php
@@ -25,7 +25,7 @@ class FetchInvoiceItemRequest extends AbstractRequest
     /**
      * Set the set invoice-item reference.
      *
-     * @return FetchInvoiceItemLinesRequest provides a fluent interface.
+     * @return FetchInvoiceItemRequest provides a fluent interface.
      */
     public function setInvoiceItemReference($value)
     {

--- a/src/Message/RefundRequest.php
+++ b/src/Message/RefundRequest.php
@@ -3,6 +3,7 @@
 /**
  * Stripe Refund Request.
  */
+
 namespace Omnipay\Stripe\Message;
 
 /**
@@ -45,7 +46,7 @@ namespace Omnipay\Stripe\Message;
  * </code>
  *
  * @see PurchaseRequest
- * @see Omnipay\Stripe\Gateway
+ * @see \Omnipay\Stripe\Gateway
  * @link https://stripe.com/docs/api#create_refund
  */
 class RefundRequest extends AbstractRequest
@@ -78,6 +79,35 @@ class RefundRequest extends AbstractRequest
         return $this->setParameter('refundApplicationFee', $value);
     }
 
+    /**
+     * @return bool Whether the transfer should be reversed
+     */
+    public function getReverseTransfer()
+    {
+        return $this->getParameter('reverseTransfer');
+    }
+
+    /**
+     * Whether to refund the application fee associated with a charge.
+     *
+     * From the {@link https://stripe.com/docs/connect/destination-charges#issuing-refunds Stripe docs}:
+     * Charges created on the platform account can be refunded using the
+     * platform account's secret key. When refunding a charge that has a
+     * `destination[account]`, by default the destination account keeps the
+     * funds that were transferred to it, leaving the platform account to
+     * cover the negative balance from the refund. To pull back the funds
+     * from the connected account to cover the refund, set the
+     * `reverse_transfer` parameter to true when creating the refund
+     *
+     * @param bool $value Whether the transfer should be refunded
+     *
+     * @return \Omnipay\Common\Message\AbstractRequest
+     */
+    public function setReverseTransfer($value)
+    {
+        return $this->setParameter('reverseTransfer', $value);
+    }
+
     public function getData()
     {
         $this->validate('transactionReference', 'amount');
@@ -87,6 +117,10 @@ class RefundRequest extends AbstractRequest
 
         if ($this->getRefundApplicationFee()) {
             $data['refund_application_fee'] = 'true';
+        }
+
+        if ($this->getReverseTransfer()) {
+            $data['reverse_transfer'] = 'true';
         }
 
         return $data;

--- a/src/Message/Response.php
+++ b/src/Message/Response.php
@@ -227,6 +227,34 @@ class Response extends AbstractResponse
     }
 
     /**
+     * Get the transfer reference from the response of CreateTransferRequest, UpdateTransferRequest, and FetchTransferRequest.
+     *
+     * @return array|null
+     */
+    public function getTransferReference()
+    {
+        if (isset($this->data['object']) && $this->data['object'] == 'transfer') {
+            return $this->data['id'];
+        }
+
+        return null;
+    }
+
+    /**
+     * Get the transfer reference from the response of CreateTransferReversalRequest, UpdateTransferReversalRequest, and FetchTransferReversalRequest.
+     *
+     * @return array|null
+     */
+    public function getTransferReversalReference()
+    {
+        if (isset($this->data['object']) && $this->data['object'] == 'transfer_reversal') {
+            return $this->data['id'];
+        }
+
+        return null;
+    }
+
+    /**
      * Get the list object from a result
      *
      * @return array|null

--- a/src/Message/Response.php
+++ b/src/Message/Response.php
@@ -35,7 +35,7 @@ class Response extends AbstractResponse
 
     /**
      * Get the charge reference from the response of FetchChargeRequest.
-     * 
+     *
      * @deprecated 2.3.3:3.0.0 duplicate of \Omnipay\Stripe\Message\Response::getTransactionReference()
      * @see \Omnipay\Stripe\Message\Response::getTransactionReference()
      * @return array|null
@@ -113,7 +113,6 @@ class Response extends AbstractResponse
     public function getCardReference()
     {
         if (isset($this->data['object']) && 'customer' === $this->data['object']) {
-            
             if (isset($this->data['default_source']) && !empty($this->data['default_source'])) {
                 return $this->data['default_source'];
             }
@@ -227,7 +226,8 @@ class Response extends AbstractResponse
     }
 
     /**
-     * Get the transfer reference from the response of CreateTransferRequest, UpdateTransferRequest, and FetchTransferRequest.
+     * Get the transfer reference from the response of CreateTransferRequest,
+     * UpdateTransferRequest, and FetchTransferRequest.
      *
      * @return array|null
      */
@@ -241,7 +241,8 @@ class Response extends AbstractResponse
     }
 
     /**
-     * Get the transfer reference from the response of CreateTransferReversalRequest, UpdateTransferReversalRequest, and FetchTransferReversalRequest.
+     * Get the transfer reference from the response of CreateTransferReversalRequest,
+     * UpdateTransferReversalRequest, and FetchTransferReversalRequest.
      *
      * @return array|null
      */

--- a/src/Message/Transfers/CreateTransferRequest.php
+++ b/src/Message/Transfers/CreateTransferRequest.php
@@ -1,0 +1,93 @@
+<?php
+
+/**
+ * Stripe Transfer Request (Connect only).
+ */
+
+namespace Omnipay\Stripe\Message\Transfers;
+
+use Omnipay\Common\Exception\InvalidRequestException;
+use Omnipay\Stripe\Message\AuthorizeRequest;
+
+/**
+ * Stripe Transfer Request.
+ *
+ * To send funds from your Stripe account to a connected account, you create
+ * a new transfer object. Your Stripe balance must be able to cover the
+ * transfer amount, or you'll receive an "Insufficient Funds" error.
+ *
+ * Example -- note this example assumes that the original charge was successful
+ *
+ * <code>
+ *   // Create the transfer object when moving funds between Stripe accounts
+ *   $transaction = $gateway->transfer(array(
+ *       'amount'        => '10.00',
+ *       'currency'      => 'AUD',
+ *       'transferGroup' => '{ORDER10}',
+ *       'destination'   => '{CONNECTED_STRIPE_ACCOUNT_ID}',
+ *   ));
+ *   $response = $transaction->send();
+ * </code>
+ *
+ * @see  AuthorizeRequest
+ * @link https://stripe.com/docs/connect/charges-transfers
+ */
+class CreateTransferRequest extends AuthorizeRequest
+{
+    /**
+     * @return mixed
+     */
+    public function getSourceTransaction()
+    {
+        return $this->getParameter('sourceTransaction');
+    }
+
+    /**
+     * When creating separate charges and transfers, your platform can
+     * inadvertently attempt a transfer without having a sufficient
+     * available balance. Doing so raises an error and the transfer
+     * attempt fails. If you’re commonly experiencing this problem, you
+     * can use the `source_transaction` parameter to tie a transfer to an
+     * existing charge. By using `source_transaction`, the transfer
+     * request succeeds regardless of your available balance and the
+     * transfer itself only occurs once the charge’s funds become available.
+     *
+     * @param string $value
+     *
+     * @return \Omnipay\Common\Message\AbstractRequest
+     */
+    public function setSourceTransaction($value)
+    {
+        return $this->setParameter('sourceTransaction', $value);
+    }
+
+    public function getData()
+    {
+        $this->validate('amount', 'currency', 'destination');
+
+        $data = [
+            'amount'      => $this->getAmountInteger(),
+            'currency'    => $this->getCurrency(),
+            'destination' => $this->getDestination(),
+        ];
+
+        if ($this->getMetadata()) {
+            $data['metadata'] = $this->getMetadata();
+        }
+
+        if ($this->getTransferGroup()) {
+            $data['transfer_group'] = $this->getTransferGroup();
+        } else if ($this->getSourceTransaction()) {
+            $data['source_transaction'] = $this->getSourceTransaction();
+        } else {
+            throw new InvalidRequestException("The sourceTransaction or transferGroup parameter is required");
+        }
+
+        return $data;
+    }
+
+    public function getEndpoint()
+    {
+        return $this->endpoint.'/transfers';
+    }
+}

--- a/src/Message/Transfers/CreateTransferRequest.php
+++ b/src/Message/Transfers/CreateTransferRequest.php
@@ -65,11 +65,11 @@ class CreateTransferRequest extends AuthorizeRequest
     {
         $this->validate('amount', 'currency', 'destination');
 
-        $data = [
-            'amount'      => $this->getAmountInteger(),
-            'currency'    => strtolower($this->getCurrency()),
+        $data = array(
+            'amount' => $this->getAmountInteger(),
+            'currency' => strtolower($this->getCurrency()),
             'destination' => $this->getDestination(),
-        ];
+        );
 
         if ($this->getMetadata()) {
             $data['metadata'] = $this->getMetadata();

--- a/src/Message/Transfers/CreateTransferRequest.php
+++ b/src/Message/Transfers/CreateTransferRequest.php
@@ -67,7 +67,7 @@ class CreateTransferRequest extends AuthorizeRequest
 
         $data = [
             'amount'      => $this->getAmountInteger(),
-            'currency'    => $this->getCurrency(),
+            'currency'    => strtolower($this->getCurrency()),
             'destination' => $this->getDestination(),
         ];
 
@@ -77,7 +77,7 @@ class CreateTransferRequest extends AuthorizeRequest
 
         if ($this->getTransferGroup()) {
             $data['transfer_group'] = $this->getTransferGroup();
-        } else if ($this->getSourceTransaction()) {
+        } elseif ($this->getSourceTransaction()) {
             $data['source_transaction'] = $this->getSourceTransaction();
         } else {
             throw new InvalidRequestException("The sourceTransaction or transferGroup parameter is required");

--- a/src/Message/Transfers/CreateTransferReversalRequest.php
+++ b/src/Message/Transfers/CreateTransferReversalRequest.php
@@ -59,7 +59,7 @@ class CreateTransferReversalRequest extends RefundRequest
     {
         $this->validate('transferReference');
 
-        $data = [];
+        $data = array();
 
         // If no amount is passed, then the entire transfer is reversed
         if ($this->getAmountInteger()) {

--- a/src/Message/Transfers/CreateTransferReversalRequest.php
+++ b/src/Message/Transfers/CreateTransferReversalRequest.php
@@ -1,0 +1,91 @@
+<?php
+
+/**
+ * Stripe Reverse Transfer Request (Connect only).
+ */
+
+namespace Omnipay\Stripe\Message\Transfers;
+
+use Omnipay\Stripe\Message\RefundRequest;
+
+/**
+ * Stripe Transfer Reversal Request.
+ *
+ * When you create a new reversal, you must specify a transfer to create it on.
+ *
+ * When reversing transfers, you can optionally reverse part of the transfer.
+ * You can do so as many times as you wish until the entire transfer has been
+ * reversed.
+ *
+ * Once entirely reversed, a transfer can't be reversed again. This method will
+ * return an error when called on an already-reversed transfer, or when trying
+ * to reverse more money than is left on a transfer.
+ *
+ * <code>
+ *   // Once the transaction has been authorized, we can capture it for final payment.
+ *   $transaction = $gateway->reverseTransfer(array(
+ *       'transferReference' => '{TRANSFER_ID}',
+ *       'description'       => 'Had to reverse this transfer because of things'
+ *   ));
+ *   $response = $transaction->send();
+ * </code>
+ *
+ * @link https://stripe.com/docs/api#create_transfer_reversal
+ */
+class CreateTransferReversalRequest extends RefundRequest
+{
+    /**
+     * @return mixed
+     */
+    public function getTransferReference()
+    {
+        return $this->getParameter('transferReference');
+    }
+
+    /**
+     * @param string $value
+     *
+     * @return \Omnipay\Common\Message\AbstractRequest
+     */
+    public function setTransferReference($value)
+    {
+        return $this->setParameter('transferReference', $value);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getData()
+    {
+        $this->validate('transferReference');
+
+        $data = [];
+
+        // If no amount is passed, then the entire transfer is reversed
+        if ($this->getAmountInteger()) {
+            $data['amount'] = $this->getAmountInteger();
+        }
+
+        if ($this->getMetadata()) {
+            $data['metadata'] = $this->getMetadata();
+        }
+
+        if ($this->getDescription()) {
+            $data['description'] = $this->getDescription();
+        }
+
+        if ($this->getRefundApplicationFee()) {
+            $data['refund_application_fee'] = 'true';
+        }
+
+        return $data;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getEndpoint()
+    {
+        return $this->endpoint.'/transfers/'.$this->getTransferReference().'/reversals';
+    }
+}

--- a/src/Message/Transfers/FetchTransferRequest.php
+++ b/src/Message/Transfers/FetchTransferRequest.php
@@ -1,0 +1,59 @@
+<?php
+
+/**
+ * Stripe Fetch Transfer Request (Connect only).
+ */
+
+namespace Omnipay\Stripe\Message\Transfers;
+
+use Omnipay\Stripe\Message\AbstractRequest;
+
+/**
+ * Stripe Fetch Transfer Request.
+ *
+ * <code>
+ *   // Once the transaction has been authorized, we can capture it for final payment.
+ *   $transaction = $gateway->fetchTransfer([
+ *       'transferReference'   => '{TRANSFER_ID}',
+ *   ]);
+ *   $response = $transaction->send();
+ * </code>
+ *
+ * @link https://stripe.com/docs/api#retrieve_transfer
+ */
+class FetchTransferRequest extends AbstractRequest
+{
+    /**
+     * @return mixed
+     */
+    public function getTransferReference()
+    {
+        return $this->getParameter('transferReference');
+    }
+
+    /**
+     * @param string $value
+     *
+     * @return \Omnipay\Common\Message\AbstractRequest
+     */
+    public function setTransferReference($value)
+    {
+        return $this->setParameter('transferReference', $value);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getData()
+    {
+        $this->validate('transferReference');
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getEndpoint()
+    {
+        return $this->endpoint.'/transfers/'.$this->getTransferReference();
+    }
+}

--- a/src/Message/Transfers/FetchTransferReversalRequest.php
+++ b/src/Message/Transfers/FetchTransferReversalRequest.php
@@ -1,0 +1,73 @@
+<?php
+
+/**
+ * Stripe Fetch Transfer Reversal Request (Connect only).
+ */
+
+namespace Omnipay\Stripe\Message\Transfers;
+
+use Omnipay\Stripe\Message\AbstractRequest;
+
+/**
+ * Stripe Fetch Transfer Reversal Request.
+ *
+ * <code>
+ *   // Once the transaction has been authorized, we can capture it for final payment.
+ *   $transaction = $gateway->fetchTransferReversal([
+ *       'transferReference' => '{TRANSFER_ID}',
+ *       'reversalReference' => '{REVERSAL_ID}',
+ *   ]);
+ *   $response = $transaction->send();
+ * </code>
+ *
+ *
+ * @link https://stripe.com/docs/api#retrieve_transfer_reversal
+ */
+class FetchTransferReversalRequest extends AbstractRequest
+{
+    /**
+     * @return mixed
+     */
+    public function getReversalReference()
+    {
+        return $this->getParameter('reversalReference');
+    }
+
+    /**
+     * @param string $value
+     *
+     * @return \Omnipay\Common\Message\AbstractRequest
+     */
+    public function setReversalReference($value)
+    {
+        return $this->setParameter('reversalReference', $value);
+    }
+
+    /**
+     * @return mixed
+     */
+    public function getTransferReference()
+    {
+        return $this->getParameter('transferReference');
+    }
+
+    /**
+     * @param string $value
+     *
+     * @return \Omnipay\Common\Message\AbstractRequest
+     */
+    public function setTransferReference($value)
+    {
+        return $this->setParameter('transferReference', $value);
+    }
+
+    public function getData()
+    {
+        $this->validate('reversalReference', 'transferReference');
+    }
+
+    public function getEndpoint()
+    {
+        return $this->endpoint.'/transfers/'.$this->getTransferReference().'/'.$this->getReversalReference();
+    }
+}

--- a/src/Message/Transfers/FetchTransferReversalRequest.php
+++ b/src/Message/Transfers/FetchTransferReversalRequest.php
@@ -68,6 +68,6 @@ class FetchTransferReversalRequest extends AbstractRequest
 
     public function getEndpoint()
     {
-        return $this->endpoint.'/transfers/'.$this->getTransferReference().'/'.$this->getReversalReference();
+        return $this->endpoint.'/transfers/'.$this->getTransferReference().'/reversals/'.$this->getReversalReference();
     }
 }

--- a/src/Message/Transfers/ListTransferReversalsRequest.php
+++ b/src/Message/Transfers/ListTransferReversalsRequest.php
@@ -1,0 +1,144 @@
+<?php
+
+/**
+ * Stripe List Transfer Reversals Request (Connect only).
+ */
+
+namespace Omnipay\Stripe\Message\Transfers;
+
+use Omnipay\Stripe\Message\AbstractRequest;
+
+/**
+ * Stripe List Transfer Reversals Request.
+ *
+ * You can see a list of the reversals belonging to a specific transfer.
+ *
+ * Note that the 10 most recent reversals are always available by default
+ * on the transfer object. If you need more than those 10, you can use
+ * this API method and the `limit` and `starting_after` parameters to
+ * page through additional reversals.
+ *
+ * @link https://stripe.com/docs/api#list_transfer_reversals
+ */
+class ListTransferReversalsRequest extends AbstractRequest
+{
+    /**
+     * @return mixed
+     */
+    public function getTransferReference()
+    {
+        return $this->getParameter('transferReference');
+    }
+
+    /**
+     * @param string $value
+     *
+     * @return \Omnipay\Common\Message\AbstractRequest
+     */
+    public function setTransferReference($value)
+    {
+        return $this->setParameter('transferReference', $value);
+    }
+
+    /**
+     * @return mixed
+     */
+    public function getLimit()
+    {
+        return $this->getParameter('limit');
+    }
+
+    /**
+     * @param string $value
+     *
+     * @return \Omnipay\Common\Message\AbstractRequest
+     */
+    public function setLimit($value)
+    {
+        return $this->setParameter('limit', $value);
+    }
+
+    /**
+     * A cursor for use in pagination. `ending_before` is an object ID that defines your place in the list.
+     * For instance, if you make a list request and receive 100 objects, starting with `obj_bar`, your
+     * subsequent call can include `ending_before=obj_ba`r in order to fetch the previous page of the list.
+     *
+     * @return mixed
+     */
+    public function getEndingBefore()
+    {
+        return $this->getParameter('endingBefore');
+    }
+
+    /**
+     * @param string $value
+     *
+     * @return \Omnipay\Common\Message\AbstractRequest
+     */
+    public function setEndingBefore($value)
+    {
+        return $this->setParameter('endingBefore', $value);
+    }
+
+    /**
+     * A cursor for use in pagination. `starting_after` is an object ID that defines your place in the list.
+     * For instance, if you make a list request and receive 100 objects, ending with `obj_foo`, your
+     * subsequent call can include `starting_after=obj_foo` in order to fetch the next page of the list.
+     *
+     * @return mixed
+     */
+    public function getStartingAfter()
+    {
+        return $this->getParameter('startingAfter');
+    }
+
+    /**
+     * @param string $value
+     *
+     * @return \Omnipay\Common\Message\AbstractRequest
+     */
+    public function setStartingAfter($value)
+    {
+        return $this->setParameter('startingAfter', $value);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getData()
+    {
+        $this->validate('transferReference');
+
+        $data = [];
+
+        if ($this->getLimit()) {
+            $data['limit'] = $this->getLimit();
+        }
+
+        if ($this->getEndingBefore()) {
+            $data['ending_before'] = $this->getEndingBefore();
+        }
+
+        if ($this->getStartingAfter()) {
+            $data['starting_after'] = $this->getStartingAfter();
+        }
+
+        return $data;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getEndpoint()
+    {
+        return $this->endpoint.'/transfers/'.$this->getTransferReference().'/reversals';
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getHttpMethod()
+    {
+        return 'GET';
+    }
+}

--- a/src/Message/Transfers/ListTransferReversalsRequest.php
+++ b/src/Message/Transfers/ListTransferReversalsRequest.php
@@ -109,7 +109,7 @@ class ListTransferReversalsRequest extends AbstractRequest
     {
         $this->validate('transferReference');
 
-        $data = [];
+        $data = array();
 
         if ($this->getLimit()) {
             $data['limit'] = $this->getLimit();

--- a/src/Message/Transfers/ListTransfersRequest.php
+++ b/src/Message/Transfers/ListTransfersRequest.php
@@ -124,7 +124,7 @@ class ListTransfersRequest extends AbstractRequest
      */
     public function getData()
     {
-        $data = [];
+        $data = array();
 
         if ($this->getLimit()) {
             $data['limit'] = $this->getLimit();

--- a/src/Message/Transfers/ListTransfersRequest.php
+++ b/src/Message/Transfers/ListTransfersRequest.php
@@ -1,0 +1,167 @@
+<?php
+
+/**
+ * Stripe List Transfers Request (Connect only).
+ */
+
+namespace Omnipay\Stripe\Message\Transfers;
+
+use Omnipay\Stripe\Message\AbstractRequest;
+
+/**
+ * Stripe List Transfers Request.
+ *
+ * Returns a list of existing transfers sent to connected accounts. The
+ * transfers are returned in sorted order, with the most recently created
+ * transfers appearing first.
+ *
+ * @link https://stripe.com/docs/api#list_transfers
+ */
+class ListTransfersRequest extends AbstractRequest
+{
+    /**
+     * @return mixed
+     */
+    public function getLimit()
+    {
+        return $this->getParameter('limit');
+    }
+
+    /**
+     * @param string $value
+     *
+     * @return \Omnipay\Common\Message\AbstractRequest
+     */
+    public function setLimit($value)
+    {
+        return $this->setParameter('limit', $value);
+    }
+
+    /**
+     * @return mixed
+     */
+    public function getDestination()
+    {
+        return $this->getParameter('destination');
+    }
+
+    /**
+     * @param string $value
+     *
+     * @return \Omnipay\Common\Message\AbstractRequest
+     */
+    public function setDestination($value)
+    {
+        return $this->setParameter('destination', $value);
+    }
+
+    /**
+     * Connect only
+     *
+     * @return mixed
+     */
+    public function getTransferGroup()
+    {
+        return $this->getParameter('transferGroup');
+    }
+
+    /**
+     * @param string $value
+     *
+     * @return \Omnipay\Common\Message\AbstractRequest
+     */
+    public function setTransferGroup($value)
+    {
+        return $this->setParameter('transferGroup', $value);
+    }
+
+    /**
+     * A cursor for use in pagination. `ending_before` is an object ID that defines your place in the list.
+     * For instance, if you make a list request and receive 100 objects, starting with `obj_bar`, your
+     * subsequent call can include `ending_before=obj_ba`r in order to fetch the previous page of the list.
+     *
+     * @return mixed
+     */
+    public function getEndingBefore()
+    {
+        return $this->getParameter('endingBefore');
+    }
+
+    /**
+     * @param string $value
+     *
+     * @return \Omnipay\Common\Message\AbstractRequest
+     */
+    public function setEndingBefore($value)
+    {
+        return $this->setParameter('endingBefore', $value);
+    }
+
+    /**
+     * A cursor for use in pagination. `starting_after` is an object ID that defines your place in the list.
+     * For instance, if you make a list request and receive 100 objects, ending with `obj_foo`, your
+     * subsequent call can include `starting_after=obj_foo` in order to fetch the next page of the list.
+     *
+     * @return mixed
+     */
+    public function getStartingAfter()
+    {
+        return $this->getParameter('startingAfter');
+    }
+
+    /**
+     * @param string $value
+     *
+     * @return \Omnipay\Common\Message\AbstractRequest
+     */
+    public function setStartingAfter($value)
+    {
+        return $this->setParameter('startingAfter', $value);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getData()
+    {
+        $data = [];
+
+        if ($this->getLimit()) {
+            $data['limit'] = $this->getLimit();
+        }
+
+        if ($this->getDestination()) {
+            $data['destination'] = $this->getDestination();
+        }
+
+        if ($this->getTransferGroup()) {
+            $data['transfer_group'] = $this->getTransferGroup();
+        }
+
+        if ($this->getEndingBefore()) {
+            $data['ending_before'] = $this->getEndingBefore();
+        }
+
+        if ($this->getStartingAfter()) {
+            $data['starting_after'] = $this->getStartingAfter();
+        }
+
+        return $data;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getEndpoint()
+    {
+        return $this->endpoint.'/transfers';
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getHttpMethod()
+    {
+        return 'GET';
+    }
+}

--- a/src/Message/Transfers/UpdateTransferRequest.php
+++ b/src/Message/Transfers/UpdateTransferRequest.php
@@ -56,7 +56,7 @@ class UpdateTransferRequest extends AbstractRequest
     {
         $this->validate('transferReference');
 
-        $data = [];
+        $data = array();
 
         if ($this->getMetadata()) {
             $data['metadata'] = $this->getMetadata();

--- a/src/Message/Transfers/UpdateTransferRequest.php
+++ b/src/Message/Transfers/UpdateTransferRequest.php
@@ -1,0 +1,75 @@
+<?php
+
+/**
+ * Stripe Update Transfer Request (Connect only).
+ */
+
+namespace Omnipay\Stripe\Message\Transfers;
+
+use Omnipay\Stripe\Message\AbstractRequest;
+
+/**
+ * Stripe Update Transfer Request.
+ *
+ * Updates the specified transfer by setting the values of the parameters passed.
+ * Any parameters not provided will be left unchanged.
+ *
+ * <code>
+ *   // Once the transaction has been authorized, we can capture it for final payment.
+ *   $transaction = $gateway->updateTransfer(array(
+ *       'transferReference' => '{TRANSFER_ID}',
+ *       'metadata'          => [],
+ *   ));
+ *   $response = $transaction->send();
+ * </code>
+ *
+ * @link https://stripe.com/docs/api#update_transfer
+ */
+class UpdateTransferRequest extends AbstractRequest
+{
+    /**
+     * Get the plan ID
+     *
+     * @return string
+     */
+    public function getTransferReference()
+    {
+        return $this->getParameter('transferReference');
+    }
+
+    /**
+     * Set the plan ID
+     *
+     * @param string $value
+     *
+     * @return \Omnipay\Common\Message\AbstractRequest
+     */
+    public function setTransferReference($value)
+    {
+        return $this->setParameter('transferReference', $value);
+    }
+
+    /**
+     * @return array
+     */
+    public function getData()
+    {
+        $this->validate('transferReference');
+
+        $data = [];
+
+        if ($this->getMetadata()) {
+            $data['metadata'] = $this->getMetadata();
+        }
+
+        return $data;
+    }
+
+    /**
+     * @return string
+     */
+    public function getEndpoint()
+    {
+        return $this->endpoint.'/transfers/'.$this->getTransferReference();
+    }
+}

--- a/src/Message/Transfers/UpdateTransferReversalRequest.php
+++ b/src/Message/Transfers/UpdateTransferReversalRequest.php
@@ -73,7 +73,7 @@ class UpdateTransferReversalRequest extends AbstractRequest
     {
         $this->validate('reversalReference', 'transferReference');
 
-        $data = [];
+        $data = array();
 
         if ($this->getMetadata()) {
             $data['metadata'] = $this->getMetadata();

--- a/src/Message/Transfers/UpdateTransferReversalRequest.php
+++ b/src/Message/Transfers/UpdateTransferReversalRequest.php
@@ -91,6 +91,6 @@ class UpdateTransferReversalRequest extends AbstractRequest
      */
     public function getEndpoint()
     {
-        return $this->endpoint.'/transfers/'.$this->getTransferReference().'/'.$this->getReversalReference();
+        return $this->endpoint.'/transfers/'.$this->getTransferReference().'/reversals/'.$this->getReversalReference();
     }
 }

--- a/src/Message/Transfers/UpdateTransferReversalRequest.php
+++ b/src/Message/Transfers/UpdateTransferReversalRequest.php
@@ -1,0 +1,96 @@
+<?php
+
+/**
+ *  Stripe Update Transfer Reversal Request (Connect only).
+ */
+
+namespace Omnipay\Stripe\Message\Transfers;
+
+use Omnipay\Stripe\Message\AbstractRequest;
+
+/**
+ * Stripe Update Transfer Reversal Request.
+ *
+ * Updates the specified reversal by setting the values of the parameters passed.
+ * Any parameters not provided will be left unchanged.
+ *
+ * This request only accepts metadata and description as arguments.
+ *
+ * <code>
+ *   // Once the transaction has been authorized, we can capture it for final payment.
+ *   $transaction = $gateway->updateTransfer(array(
+ *       'transferReference' => '{TRANSFER_ID}',
+ *       'reversalReference' => '{REVERSAL_ID}',
+ *       'metadata'          => [],
+ *   ));
+ *   $response = $transaction->send();
+ * </code>
+ *
+ * @link https://stripe.com/docs/api#update_transfer_reversal
+ */
+class UpdateTransferReversalRequest extends AbstractRequest
+{
+    /**
+     * @return mixed
+     */
+    public function getReversalReference()
+    {
+        return $this->getParameter('reversalReference');
+    }
+
+    /**
+     * @param string $value
+     *
+     * @return \Omnipay\Common\Message\AbstractRequest
+     */
+    public function setReversalReference($value)
+    {
+        return $this->setParameter('reversalReference', $value);
+    }
+
+    /**
+     * @return mixed
+     */
+    public function getTransferReference()
+    {
+        return $this->getParameter('transferReference');
+    }
+
+    /**
+     * @param string $value
+     *
+     * @return \Omnipay\Common\Message\AbstractRequest
+     */
+    public function setTransferReference($value)
+    {
+        return $this->setParameter('transferReference', $value);
+    }
+
+    /**
+     * @return array
+     */
+    public function getData()
+    {
+        $this->validate('reversalReference', 'transferReference');
+
+        $data = [];
+
+        if ($this->getMetadata()) {
+            $data['metadata'] = $this->getMetadata();
+        }
+
+        if ($this->getDescription()) {
+            $data['description'] = $this->getDescription();
+        }
+
+        return $data;
+    }
+
+    /**
+     * @return string
+     */
+    public function getEndpoint()
+    {
+        return $this->endpoint.'/transfers/'.$this->getTransferReference().'/'.$this->getReversalReference();
+    }
+}

--- a/tests/Message/AbstractRequestTest.php
+++ b/tests/Message/AbstractRequestTest.php
@@ -56,4 +56,47 @@ class AbstractRequestTest extends TestCase
         $this->assertSame($this->request, $this->request->setMetadata(array('foo' => 'bar')));
         $this->assertSame(array('foo' => 'bar'), $this->request->getMetadata());
     }
+
+    public function testIdempotencyKey()
+    {
+        $this->request->setIdempotencyKeyHeader('UUID');
+
+        $this->assertSame('UUID', $this->request->getIdempotencyKeyHeader());
+
+        $headers = $this->request->getHeaders();
+
+        $this->assertArrayHasKey('Idempotency-Key', $headers);
+        $this->assertSame('UUID', $headers['Idempotency-Key']);
+
+        $httpRequest = $this->getHttpClient()->createRequest(
+            'GET',
+            '/',
+            $headers,
+            []
+        );
+
+        $this->assertTrue($httpRequest->hasHeader('Idempotency-Key'));
+    }
+
+
+    public function testConnectedStripeAccount()
+    {
+        $this->request->setConnectedStripeAccountHeader('ACCOUNT_ID');
+
+        $this->assertSame('ACCOUNT_ID', $this->request->getConnectedStripeAccountHeader());
+
+        $headers = $this->request->getHeaders();
+
+        $this->assertArrayHasKey('Stripe-Account', $headers);
+        $this->assertSame('ACCOUNT_ID', $headers['Stripe-Account']);
+
+        $httpRequest = $this->getHttpClient()->createRequest(
+            'GET',
+            '/',
+            $headers,
+            []
+        );
+
+        $this->assertTrue($httpRequest->hasHeader('Stripe-Account'));
+    }
 }

--- a/tests/Message/AbstractRequestTest.php
+++ b/tests/Message/AbstractRequestTest.php
@@ -72,7 +72,7 @@ class AbstractRequestTest extends TestCase
             'GET',
             '/',
             $headers,
-            []
+            array()
         );
 
         $this->assertTrue($httpRequest->hasHeader('Idempotency-Key'));
@@ -94,7 +94,7 @@ class AbstractRequestTest extends TestCase
             'GET',
             '/',
             $headers,
-            []
+            array()
         );
 
         $this->assertTrue($httpRequest->hasHeader('Stripe-Account'));

--- a/tests/Message/CaptureRequestTest.php
+++ b/tests/Message/CaptureRequestTest.php
@@ -19,7 +19,7 @@ class CaptureRequestTest extends TestCase
 
     public function testAmount()
     {
-        // defualt is no amount
+        // default is no amount
         $this->assertArrayNotHasKey('amount', $this->request->getData());
 
         $this->request->setAmount('10.00');

--- a/tests/Message/Transfers/CreateTransferRequestTest.php
+++ b/tests/Message/Transfers/CreateTransferRequestTest.php
@@ -1,0 +1,85 @@
+<?php
+
+namespace Omnipay\Stripe\Message\Transfers;
+
+use Guzzle\Http\Message\Response;
+use Omnipay\Tests\TestCase;
+
+class CreateTransferRequestTest extends TestCase
+{
+    /**
+     * @var \Omnipay\Stripe\Message\Transfers\CreateTransferRequest
+     */
+    protected $request;
+
+    public function setUp()
+    {
+        $this->request = new CreateTransferRequest($this->getHttpClient(), $this->getHttpRequest());
+        $this->request->initialize(
+            [
+                'amount'        => '12.00',
+                'currency'      => 'USD',
+                'destination'   => 'STRIPE_ACCOUNT_ID',
+                'transferGroup' => 'Order42',
+                'metadata'      => [
+                    'foo' => 'bar',
+                ],
+            ]
+        );
+    }
+
+    public function testGetData()
+    {
+        $data = $this->request->getData();
+
+        $this->assertSame(1200, $data['amount']);
+        $this->assertSame('usd', $data['currency']);
+        $this->assertSame('STRIPE_ACCOUNT_ID', $data['destination']);
+        $this->assertSame('Order42', $data['transfer_group']);
+        $this->assertSame(['foo' => 'bar'], $data['metadata']);
+    }
+
+    /**
+     * @expectedException \Omnipay\Common\Exception\InvalidRequestException
+     * @expectedExceptionMessage The sourceTransaction or transferGroup parameter is required
+     */
+    public function testReferenceRequired()
+    {
+        $this->request->setTransferGroup(null);
+        $this->request->getData();
+    }
+
+    public function testDataWithSourceTransactionReference()
+    {
+        $this->request->setTransferGroup(null);
+        $this->request->setSourceTransaction('abc');
+        $data = $this->request->getData();
+
+        $this->assertSame('abc', $data['source_transaction']);
+    }
+
+    public function testSendSuccess()
+    {
+        $this->setMockHttpResponse(
+            [Response::fromMessage(file_get_contents(__DIR__ . '/../../Mock/Transfers/CreateTransferRequestSuccess.txt'))]
+        );
+        $response = $this->request->send();
+
+        $this->assertTrue($response->isSuccessful());
+        $this->assertFalse($response->isRedirect());
+        $this->assertSame('tr_164xRv2eZvKYlo2CZxJZWm1E', $response->getTransferReference());
+        $this->assertNull($response->getMessage());
+    }
+
+    public function testSendError()
+    {
+        $this->setMockHttpResponse(
+            [Response::fromMessage(file_get_contents(__DIR__ . '/../../Mock/Transfers/CreateTransferRequestFailure.txt'))]
+        );
+        $response = $this->request->send();
+
+        $this->assertFalse($response->isSuccessful());
+        $this->assertFalse($response->isRedirect());
+        $this->assertSame('Transfer does not have available funds', $response->getMessage());
+    }
+}

--- a/tests/Message/Transfers/CreateTransferRequestTest.php
+++ b/tests/Message/Transfers/CreateTransferRequestTest.php
@@ -16,15 +16,15 @@ class CreateTransferRequestTest extends TestCase
     {
         $this->request = new CreateTransferRequest($this->getHttpClient(), $this->getHttpRequest());
         $this->request->initialize(
-            [
-                'amount'        => '12.00',
-                'currency'      => 'USD',
-                'destination'   => 'STRIPE_ACCOUNT_ID',
+            array(
+                'amount' => '12.00',
+                'currency' => 'USD',
+                'destination' => 'STRIPE_ACCOUNT_ID',
                 'transferGroup' => 'Order42',
-                'metadata'      => [
+                'metadata' => array(
                     'foo' => 'bar',
-                ],
-            ]
+                ),
+            )
         );
     }
 
@@ -36,7 +36,7 @@ class CreateTransferRequestTest extends TestCase
         $this->assertSame('usd', $data['currency']);
         $this->assertSame('STRIPE_ACCOUNT_ID', $data['destination']);
         $this->assertSame('Order42', $data['transfer_group']);
-        $this->assertSame(['foo' => 'bar'], $data['metadata']);
+        $this->assertSame(array('foo' => 'bar'), $data['metadata']);
     }
 
     /**
@@ -61,7 +61,7 @@ class CreateTransferRequestTest extends TestCase
     public function testSendSuccess()
     {
         $this->setMockHttpResponse(
-            [Response::fromMessage(file_get_contents(__DIR__ . '/../../Mock/Transfers/CreateTransferRequestSuccess.txt'))]
+            array(Response::fromMessage(file_get_contents(__DIR__.'/../../Mock/Transfers/CreateTransferRequestSuccess.txt')))
         );
         $response = $this->request->send();
 
@@ -74,7 +74,7 @@ class CreateTransferRequestTest extends TestCase
     public function testSendError()
     {
         $this->setMockHttpResponse(
-            [Response::fromMessage(file_get_contents(__DIR__ . '/../../Mock/Transfers/CreateTransferRequestFailure.txt'))]
+            array(Response::fromMessage(file_get_contents(__DIR__.'/../../Mock/Transfers/CreateTransferRequestFailure.txt')))
         );
         $response = $this->request->send();
 

--- a/tests/Message/Transfers/CreateTransferRequestTest.php
+++ b/tests/Message/Transfers/CreateTransferRequestTest.php
@@ -8,12 +8,18 @@ use Omnipay\Tests\TestCase;
 class CreateTransferRequestTest extends TestCase
 {
     /**
-     * @var \Omnipay\Stripe\Message\Transfers\CreateTransferRequest
+     * @var CreateTransferRequest
      */
     protected $request;
 
+    /**
+     * @var string
+     */
+    protected $mockDir;
+
     public function setUp()
     {
+        $this->mockDir = __DIR__.'/../../Mock/Transfers';
         $this->request = new CreateTransferRequest($this->getHttpClient(), $this->getHttpRequest());
         $this->request->initialize(
             array(
@@ -61,7 +67,7 @@ class CreateTransferRequestTest extends TestCase
     public function testSendSuccess()
     {
         $this->setMockHttpResponse(
-            array(Response::fromMessage(file_get_contents(__DIR__.'/../../Mock/Transfers/CreateTransferRequestSuccess.txt')))
+            array(Response::fromMessage(file_get_contents($this->mockDir.'/CreateTransferRequestSuccess.txt')))
         );
         $response = $this->request->send();
 
@@ -74,7 +80,7 @@ class CreateTransferRequestTest extends TestCase
     public function testSendError()
     {
         $this->setMockHttpResponse(
-            array(Response::fromMessage(file_get_contents(__DIR__.'/../../Mock/Transfers/CreateTransferRequestFailure.txt')))
+            array(Response::fromMessage(file_get_contents($this->mockDir.'/CreateTransferRequestFailure.txt')))
         );
         $response = $this->request->send();
 

--- a/tests/Message/Transfers/CreateTransferReversalRequestTest.php
+++ b/tests/Message/Transfers/CreateTransferReversalRequestTest.php
@@ -8,12 +8,18 @@ use Omnipay\Tests\TestCase;
 class CreateTransferReversalRequestTest extends TestCase
 {
     /**
-     * @var \Omnipay\Stripe\Message\Transfers\CreateTransferReversalRequest
+     * @var CreateTransferReversalRequest
      */
     protected $request;
 
+    /**
+     * @var string
+     */
+    protected $mockDir;
+
     public function setUp()
     {
+        $this->mockDir = __DIR__.'/../../Mock/Transfers';
         $this->request = new CreateTransferReversalRequest($this->getHttpClient(), $this->getHttpRequest());
         $this->request->initialize(
             array(
@@ -39,7 +45,7 @@ class CreateTransferReversalRequestTest extends TestCase
     public function testSendSuccess()
     {
         $this->setMockHttpResponse(
-            array(Response::fromMessage(file_get_contents(__DIR__.'/../../Mock/Transfers/CreateTransferReversalRequestSuccess.txt')))
+            array(Response::fromMessage(file_get_contents($this->mockDir.'/CreateTransferReversalRequestSuccess.txt')))
         );
 
         /** @var \Omnipay\Stripe\Message\Response $response */
@@ -54,7 +60,7 @@ class CreateTransferReversalRequestTest extends TestCase
     public function testSendFailure()
     {
         $this->setMockHttpResponse(
-            array(Response::fromMessage(file_get_contents(__DIR__.'/../../Mock/Transfers/FetchTransferReversalFailure.txt')))
+            array(Response::fromMessage(file_get_contents($this->mockDir.'/FetchTransferReversalFailure.txt')))
         );
         $response = $this->request->send();
 
@@ -62,5 +68,4 @@ class CreateTransferReversalRequestTest extends TestCase
         $this->assertFalse($response->isRedirect());
         $this->assertSame('No such transfer reversal: trr_1ARKQ22eZvKYlo2Cv5APdtKF', $response->getMessage());
     }
-
 }

--- a/tests/Message/Transfers/CreateTransferReversalRequestTest.php
+++ b/tests/Message/Transfers/CreateTransferReversalRequestTest.php
@@ -16,14 +16,14 @@ class CreateTransferReversalRequestTest extends TestCase
     {
         $this->request = new CreateTransferReversalRequest($this->getHttpClient(), $this->getHttpRequest());
         $this->request->initialize(
-            [
+            array(
                 'transferReference' => 'REVERSAL_ID',
-                'amount'            => '12.00',
-                'description'       => 'Reversing Order 42',
-                'metadata'          => [
+                'amount' => '12.00',
+                'description' => 'Reversing Order 42',
+                'metadata' => array(
                     'foo' => 'bar',
-                ],
-            ]
+                ),
+            )
         );
     }
 
@@ -33,13 +33,13 @@ class CreateTransferReversalRequestTest extends TestCase
 
         $this->assertSame(1200, $data['amount']);
         $this->assertSame('Reversing Order 42', $data['description']);
-        $this->assertSame(['foo' => 'bar'], $data['metadata']);
+        $this->assertSame(array('foo' => 'bar'), $data['metadata']);
     }
 
     public function testSendSuccess()
     {
         $this->setMockHttpResponse(
-            [Response::fromMessage(file_get_contents(__DIR__ . '/../../Mock/Transfers/CreateTransferReversalRequestSuccess.txt'))]
+            array(Response::fromMessage(file_get_contents(__DIR__.'/../../Mock/Transfers/CreateTransferReversalRequestSuccess.txt')))
         );
 
         /** @var \Omnipay\Stripe\Message\Response $response */
@@ -54,7 +54,7 @@ class CreateTransferReversalRequestTest extends TestCase
     public function testSendFailure()
     {
         $this->setMockHttpResponse(
-            [Response::fromMessage(file_get_contents(__DIR__ . '/../../Mock/Transfers/FetchTransferReversalFailure.txt'))]
+            array(Response::fromMessage(file_get_contents(__DIR__.'/../../Mock/Transfers/FetchTransferReversalFailure.txt')))
         );
         $response = $this->request->send();
 

--- a/tests/Message/Transfers/CreateTransferReversalRequestTest.php
+++ b/tests/Message/Transfers/CreateTransferReversalRequestTest.php
@@ -1,0 +1,66 @@
+<?php
+
+namespace Omnipay\Stripe\Message\Transfers;
+
+use Guzzle\Http\Message\Response;
+use Omnipay\Tests\TestCase;
+
+class CreateTransferReversalRequestTest extends TestCase
+{
+    /**
+     * @var \Omnipay\Stripe\Message\Transfers\CreateTransferReversalRequest
+     */
+    protected $request;
+
+    public function setUp()
+    {
+        $this->request = new CreateTransferReversalRequest($this->getHttpClient(), $this->getHttpRequest());
+        $this->request->initialize(
+            [
+                'transferReference' => 'REVERSAL_ID',
+                'amount'            => '12.00',
+                'description'       => 'Reversing Order 42',
+                'metadata'          => [
+                    'foo' => 'bar',
+                ],
+            ]
+        );
+    }
+
+    public function testGetData()
+    {
+        $data = $this->request->getData();
+
+        $this->assertSame(1200, $data['amount']);
+        $this->assertSame('Reversing Order 42', $data['description']);
+        $this->assertSame(['foo' => 'bar'], $data['metadata']);
+    }
+
+    public function testSendSuccess()
+    {
+        $this->setMockHttpResponse(
+            [Response::fromMessage(file_get_contents(__DIR__ . '/../../Mock/Transfers/CreateTransferReversalRequestSuccess.txt'))]
+        );
+
+        /** @var \Omnipay\Stripe\Message\Response $response */
+        $response = $this->request->send();
+
+        $this->assertTrue($response->isSuccessful());
+        $this->assertFalse($response->isRedirect());
+        $this->assertSame('trr_1ARKQ22eZvKYlo2Cv5APdtKF', $response->getTransferReversalReference());
+        $this->assertNull($response->getMessage());
+    }
+
+    public function testSendFailure()
+    {
+        $this->setMockHttpResponse(
+            [Response::fromMessage(file_get_contents(__DIR__ . '/../../Mock/Transfers/FetchTransferReversalFailure.txt'))]
+        );
+        $response = $this->request->send();
+
+        $this->assertFalse($response->isSuccessful());
+        $this->assertFalse($response->isRedirect());
+        $this->assertSame('No such transfer reversal: trr_1ARKQ22eZvKYlo2Cv5APdtKF', $response->getMessage());
+    }
+
+}

--- a/tests/Message/Transfers/FetchTransferRequestTest.php
+++ b/tests/Message/Transfers/FetchTransferRequestTest.php
@@ -20,13 +20,16 @@ class FetchTransferRequestTest extends TestCase
 
     public function testEndpoint()
     {
-        $this->assertSame('https://api.stripe.com/v1/transfers/tr_164xRv2eZvKYlo2CZxJZWm1E', $this->request->getEndpoint());
+        $this->assertSame(
+            'https://api.stripe.com/v1/transfers/tr_164xRv2eZvKYlo2CZxJZWm1E',
+            $this->request->getEndpoint()
+        );
     }
 
     public function testSendSuccess()
     {
         $this->setMockHttpResponse(
-            [Response::fromMessage(file_get_contents(__DIR__ . '/../../Mock/Transfers/FetchTransferSuccess.txt'))]
+            array(Response::fromMessage(file_get_contents(__DIR__.'/../../Mock/Transfers/FetchTransferSuccess.txt')))
         );
 
         /** @var \Omnipay\Stripe\Message\Response $response */
@@ -41,7 +44,7 @@ class FetchTransferRequestTest extends TestCase
     public function testSendFailure()
     {
         $this->setMockHttpResponse(
-            [Response::fromMessage(file_get_contents(__DIR__ . '/../../Mock/Transfers/FetchTransferFailure.txt'))]
+            array(Response::fromMessage(file_get_contents(__DIR__.'/../../Mock/Transfers/FetchTransferFailure.txt')))
         );
         $response = $this->request->send();
 

--- a/tests/Message/Transfers/FetchTransferRequestTest.php
+++ b/tests/Message/Transfers/FetchTransferRequestTest.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace Omnipay\Stripe\Message\Transfers;
+
+use Guzzle\Http\Message\Response;
+use Omnipay\Tests\TestCase;
+
+class FetchTransferRequestTest extends TestCase
+{
+    /**
+     * @var \Omnipay\Stripe\Message\Transfers\FetchTransferRequest
+     */
+    private $request;
+
+    public function setUp()
+    {
+        $this->request = new FetchTransferRequest($this->getHttpClient(), $this->getHttpRequest());
+        $this->request->setTransferReference('tr_164xRv2eZvKYlo2CZxJZWm1E');
+    }
+
+    public function testEndpoint()
+    {
+        $this->assertSame('https://api.stripe.com/v1/transfers/tr_164xRv2eZvKYlo2CZxJZWm1E', $this->request->getEndpoint());
+    }
+
+    public function testSendSuccess()
+    {
+        $this->setMockHttpResponse(
+            [Response::fromMessage(file_get_contents(__DIR__ . '/../../Mock/Transfers/FetchTransferSuccess.txt'))]
+        );
+
+        /** @var \Omnipay\Stripe\Message\Response $response */
+        $response = $this->request->send();
+
+        $this->assertTrue($response->isSuccessful());
+        $this->assertSame('tr_164xRv2eZvKYlo2CZxJZWm1E', $response->getTransferReference());
+        $this->assertFalse($response->isRedirect());
+        $this->assertNull($response->getMessage());
+    }
+
+    public function testSendFailure()
+    {
+        $this->setMockHttpResponse(
+            [Response::fromMessage(file_get_contents(__DIR__ . '/../../Mock/Transfers/FetchTransferFailure.txt'))]
+        );
+        $response = $this->request->send();
+
+        $this->assertFalse($response->isSuccessful());
+        $this->assertFalse($response->isRedirect());
+        $this->assertSame('No such transfer: tr_164xRv2eZvKYlo2CZxJZWm1E', $response->getMessage());
+    }
+}

--- a/tests/Message/Transfers/FetchTransferRequestTest.php
+++ b/tests/Message/Transfers/FetchTransferRequestTest.php
@@ -8,12 +8,18 @@ use Omnipay\Tests\TestCase;
 class FetchTransferRequestTest extends TestCase
 {
     /**
-     * @var \Omnipay\Stripe\Message\Transfers\FetchTransferRequest
+     * @var FetchTransferRequest
      */
-    private $request;
+    protected $request;
+
+    /**
+     * @var string
+     */
+    protected $mockDir;
 
     public function setUp()
     {
+        $this->mockDir = __DIR__.'/../../Mock/Transfers';
         $this->request = new FetchTransferRequest($this->getHttpClient(), $this->getHttpRequest());
         $this->request->setTransferReference('tr_164xRv2eZvKYlo2CZxJZWm1E');
     }
@@ -29,7 +35,7 @@ class FetchTransferRequestTest extends TestCase
     public function testSendSuccess()
     {
         $this->setMockHttpResponse(
-            array(Response::fromMessage(file_get_contents(__DIR__.'/../../Mock/Transfers/FetchTransferSuccess.txt')))
+            array(Response::fromMessage(file_get_contents($this->mockDir.'/FetchTransferSuccess.txt')))
         );
 
         /** @var \Omnipay\Stripe\Message\Response $response */
@@ -44,7 +50,7 @@ class FetchTransferRequestTest extends TestCase
     public function testSendFailure()
     {
         $this->setMockHttpResponse(
-            array(Response::fromMessage(file_get_contents(__DIR__.'/../../Mock/Transfers/FetchTransferFailure.txt')))
+            array(Response::fromMessage(file_get_contents($this->mockDir.'/FetchTransferFailure.txt')))
         );
         $response = $this->request->send();
 

--- a/tests/Message/Transfers/FetchTransferReversalRequestTest.php
+++ b/tests/Message/Transfers/FetchTransferReversalRequestTest.php
@@ -21,13 +21,16 @@ class FetchTransferReversalRequestTest extends TestCase
 
     public function testEndpoint()
     {
-        $this->assertSame('https://api.stripe.com/v1/transfers/tr_1ARKPl2eZvKYlo2CsNTKWIOO/reversals/trr_1ARKQ22eZvKYlo2Cv5APdtKF', $this->request->getEndpoint());
+        $this->assertSame(
+            'https://api.stripe.com/v1/transfers/tr_1ARKPl2eZvKYlo2CsNTKWIOO/reversals/trr_1ARKQ22eZvKYlo2Cv5APdtKF',
+            $this->request->getEndpoint()
+        );
     }
 
     public function testSendSuccess()
     {
         $this->setMockHttpResponse(
-            [Response::fromMessage(file_get_contents(__DIR__ . '/../../Mock/Transfers/FetchTransferReversalSuccess.txt'))]
+            array(Response::fromMessage(file_get_contents(__DIR__.'/../../Mock/Transfers/FetchTransferReversalSuccess.txt')))
         );
 
         /** @var \Omnipay\Stripe\Message\Response $response */
@@ -42,7 +45,7 @@ class FetchTransferReversalRequestTest extends TestCase
     public function testSendFailure()
     {
         $this->setMockHttpResponse(
-            [Response::fromMessage(file_get_contents(__DIR__ . '/../../Mock/Transfers/FetchTransferReversalFailure.txt'))]
+            array(Response::fromMessage(file_get_contents(__DIR__.'/../../Mock/Transfers/FetchTransferReversalFailure.txt')))
         );
         $response = $this->request->send();
 

--- a/tests/Message/Transfers/FetchTransferReversalRequestTest.php
+++ b/tests/Message/Transfers/FetchTransferReversalRequestTest.php
@@ -8,12 +8,18 @@ use Omnipay\Tests\TestCase;
 class FetchTransferReversalRequestTest extends TestCase
 {
     /**
-     * @var \Omnipay\Stripe\Message\Transfers\FetchTransferReversalRequest
+     * @var FetchTransferReversalRequest
      */
-    private $request;
+    protected $request;
+
+    /**
+     * @var string
+     */
+    protected $mockDir;
 
     public function setUp()
     {
+        $this->mockDir = __DIR__.'/../../Mock/Transfers';
         $this->request = new FetchTransferReversalRequest($this->getHttpClient(), $this->getHttpRequest());
         $this->request->setTransferReference('tr_1ARKPl2eZvKYlo2CsNTKWIOO');
         $this->request->setReversalReference('trr_1ARKQ22eZvKYlo2Cv5APdtKF');
@@ -30,7 +36,7 @@ class FetchTransferReversalRequestTest extends TestCase
     public function testSendSuccess()
     {
         $this->setMockHttpResponse(
-            array(Response::fromMessage(file_get_contents(__DIR__.'/../../Mock/Transfers/FetchTransferReversalSuccess.txt')))
+            array(Response::fromMessage(file_get_contents($this->mockDir.'/FetchTransferReversalSuccess.txt')))
         );
 
         /** @var \Omnipay\Stripe\Message\Response $response */
@@ -45,7 +51,7 @@ class FetchTransferReversalRequestTest extends TestCase
     public function testSendFailure()
     {
         $this->setMockHttpResponse(
-            array(Response::fromMessage(file_get_contents(__DIR__.'/../../Mock/Transfers/FetchTransferReversalFailure.txt')))
+            array(Response::fromMessage(file_get_contents($this->mockDir.'/FetchTransferReversalFailure.txt')))
         );
         $response = $this->request->send();
 

--- a/tests/Message/Transfers/FetchTransferReversalRequestTest.php
+++ b/tests/Message/Transfers/FetchTransferReversalRequestTest.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace Omnipay\Stripe\Message\Transfers;
+
+use Guzzle\Http\Message\Response;
+use Omnipay\Tests\TestCase;
+
+class FetchTransferReversalRequestTest extends TestCase
+{
+    /**
+     * @var \Omnipay\Stripe\Message\Transfers\FetchTransferReversalRequest
+     */
+    private $request;
+
+    public function setUp()
+    {
+        $this->request = new FetchTransferReversalRequest($this->getHttpClient(), $this->getHttpRequest());
+        $this->request->setTransferReference('tr_1ARKPl2eZvKYlo2CsNTKWIOO');
+        $this->request->setReversalReference('trr_1ARKQ22eZvKYlo2Cv5APdtKF');
+    }
+
+    public function testEndpoint()
+    {
+        $this->assertSame('https://api.stripe.com/v1/transfers/tr_1ARKPl2eZvKYlo2CsNTKWIOO/reversals/trr_1ARKQ22eZvKYlo2Cv5APdtKF', $this->request->getEndpoint());
+    }
+
+    public function testSendSuccess()
+    {
+        $this->setMockHttpResponse(
+            [Response::fromMessage(file_get_contents(__DIR__ . '/../../Mock/Transfers/FetchTransferReversalSuccess.txt'))]
+        );
+
+        /** @var \Omnipay\Stripe\Message\Response $response */
+        $response = $this->request->send();
+
+        $this->assertTrue($response->isSuccessful());
+        $this->assertSame('trr_1ARKQ22eZvKYlo2Cv5APdtKF', $response->getTransferReversalReference());
+        $this->assertFalse($response->isRedirect());
+        $this->assertNull($response->getMessage());
+    }
+
+    public function testSendFailure()
+    {
+        $this->setMockHttpResponse(
+            [Response::fromMessage(file_get_contents(__DIR__ . '/../../Mock/Transfers/FetchTransferReversalFailure.txt'))]
+        );
+        $response = $this->request->send();
+
+        $this->assertFalse($response->isSuccessful());
+        $this->assertFalse($response->isRedirect());
+        $this->assertSame('No such transfer reversal: trr_1ARKQ22eZvKYlo2Cv5APdtKF', $response->getMessage());
+    }
+}

--- a/tests/Message/Transfers/ListTransferReversalsRequestTest.php
+++ b/tests/Message/Transfers/ListTransferReversalsRequestTest.php
@@ -19,13 +19,16 @@ class ListTransferReversalsRequestTest extends TestCase
 
     public function testEndpoint()
     {
-        $this->assertSame('https://api.stripe.com/v1/transfers/tr_164xRv2eZvKYlo2CZxJZWm1E/reversals', $this->request->getEndpoint());
+        $this->assertSame(
+            'https://api.stripe.com/v1/transfers/tr_164xRv2eZvKYlo2CZxJZWm1E/reversals',
+            $this->request->getEndpoint()
+        );
     }
 
     public function testSendSuccess()
     {
         $this->setMockHttpResponse(
-            [Response::fromMessage(file_get_contents(__DIR__ . '/../../Mock/Transfers/ListTransferReversalsSuccess.txt'))]
+            array(Response::fromMessage(file_get_contents(__DIR__.'/../../Mock/Transfers/ListTransferReversalsSuccess.txt')))
         );
 
         /** @var \Omnipay\Stripe\Message\Response $response */
@@ -45,7 +48,7 @@ class ListTransferReversalsRequestTest extends TestCase
         $this->request->setTransferReference('NOTFOUND');
 
         $this->setMockHttpResponse(
-            [Response::fromMessage(file_get_contents(__DIR__ . '/../../Mock/Transfers/ListTransferReversalsFailure.txt'))]
+            array(Response::fromMessage(file_get_contents(__DIR__.'/../../Mock/Transfers/ListTransferReversalsFailure.txt')))
         );
         $response = $this->request->send();
 

--- a/tests/Message/Transfers/ListTransferReversalsRequestTest.php
+++ b/tests/Message/Transfers/ListTransferReversalsRequestTest.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace Omnipay\Stripe\Message\Transfers;
+
+use Guzzle\Http\Message\Response;
+use Omnipay\Tests\TestCase;
+
+class ListTransferReversalsRequestTest extends TestCase
+{
+
+    /** @var ListTransferReversalsRequest */
+    protected $request;
+
+    public function setUp()
+    {
+        $this->request = new ListTransferReversalsRequest($this->getHttpClient(), $this->getHttpRequest());
+        $this->request->setTransferReference('tr_164xRv2eZvKYlo2CZxJZWm1E');
+    }
+
+    public function testEndpoint()
+    {
+        $this->assertSame('https://api.stripe.com/v1/transfers/tr_164xRv2eZvKYlo2CZxJZWm1E/reversals', $this->request->getEndpoint());
+    }
+
+    public function testSendSuccess()
+    {
+        $this->setMockHttpResponse(
+            [Response::fromMessage(file_get_contents(__DIR__ . '/../../Mock/Transfers/ListTransferReversalsSuccess.txt'))]
+        );
+
+        /** @var \Omnipay\Stripe\Message\Response $response */
+        $response = $this->request->send();
+
+        $data = $response->getData();
+
+        $this->assertTrue($response->isSuccessful());
+        $this->assertNotNull($response->getList());
+        $this->assertNull($response->getMessage());
+        $this->assertSame('/v1/transfers/tr_164xRv2eZvKYlo2CZxJZWm1E/reversals', $data['url']);
+        $this->assertFalse($response->isRedirect());
+    }
+
+    public function testSendFailure()
+    {
+        $this->request->setTransferReference('NOTFOUND');
+
+        $this->setMockHttpResponse(
+            [Response::fromMessage(file_get_contents(__DIR__ . '/../../Mock/Transfers/ListTransferReversalsFailure.txt'))]
+        );
+        $response = $this->request->send();
+
+        $this->assertFalse($response->isSuccessful());
+        $this->assertFalse($response->isRedirect());
+        $this->assertSame('No such transfer: NOTFOUND', $response->getMessage());
+    }
+}

--- a/tests/Message/Transfers/ListTransferReversalsRequestTest.php
+++ b/tests/Message/Transfers/ListTransferReversalsRequestTest.php
@@ -7,12 +7,19 @@ use Omnipay\Tests\TestCase;
 
 class ListTransferReversalsRequestTest extends TestCase
 {
-
-    /** @var ListTransferReversalsRequest */
+    /**
+     * @var ListTransferReversalsRequest
+     */
     protected $request;
+
+    /**
+     * @var string
+     */
+    protected $mockDir;
 
     public function setUp()
     {
+        $this->mockDir = __DIR__.'/../../Mock/Transfers';
         $this->request = new ListTransferReversalsRequest($this->getHttpClient(), $this->getHttpRequest());
         $this->request->setTransferReference('tr_164xRv2eZvKYlo2CZxJZWm1E');
     }
@@ -28,7 +35,7 @@ class ListTransferReversalsRequestTest extends TestCase
     public function testSendSuccess()
     {
         $this->setMockHttpResponse(
-            array(Response::fromMessage(file_get_contents(__DIR__.'/../../Mock/Transfers/ListTransferReversalsSuccess.txt')))
+            array(Response::fromMessage(file_get_contents($this->mockDir.'/ListTransferReversalsSuccess.txt')))
         );
 
         /** @var \Omnipay\Stripe\Message\Response $response */
@@ -48,7 +55,7 @@ class ListTransferReversalsRequestTest extends TestCase
         $this->request->setTransferReference('NOTFOUND');
 
         $this->setMockHttpResponse(
-            array(Response::fromMessage(file_get_contents(__DIR__.'/../../Mock/Transfers/ListTransferReversalsFailure.txt')))
+            array(Response::fromMessage(file_get_contents($this->mockDir.'/ListTransferReversalsFailure.txt')))
         );
         $response = $this->request->send();
 

--- a/tests/Message/Transfers/ListTransfersRequestTest.php
+++ b/tests/Message/Transfers/ListTransfersRequestTest.php
@@ -7,12 +7,19 @@ use Omnipay\Tests\TestCase;
 
 class ListTransfersRequestTest extends TestCase
 {
-
-    /** @var  ListTransfersRequest */
+    /**
+     * @var ListTransfersRequest
+     */
     protected $request;
+
+    /**
+     * @var string
+     */
+    protected $mockDir;
 
     public function setUp()
     {
+        $this->mockDir = __DIR__.'/../../Mock/Transfers';
         $this->request = new ListTransfersRequest($this->getHttpClient(), $this->getHttpRequest());
     }
 
@@ -24,7 +31,7 @@ class ListTransfersRequestTest extends TestCase
     public function testSendSuccess()
     {
         $this->setMockHttpResponse(
-            array(Response::fromMessage(file_get_contents(__DIR__.'/../../Mock/Transfers/ListTransfersSuccess.txt')))
+            array(Response::fromMessage(file_get_contents($this->mockDir.'/ListTransfersSuccess.txt')))
         );
 
         /** @var \Omnipay\Stripe\Message\Response $response */
@@ -44,7 +51,7 @@ class ListTransfersRequestTest extends TestCase
         $this->request->setTransferGroup('NOTFOUND');
 
         $this->setMockHttpResponse(
-            array(Response::fromMessage(file_get_contents(__DIR__.'/../../Mock/Transfers/ListTransfersFailure.txt')))
+            array(Response::fromMessage(file_get_contents($this->mockDir.'/ListTransfersFailure.txt')))
         );
         $response = $this->request->send();
 

--- a/tests/Message/Transfers/ListTransfersRequestTest.php
+++ b/tests/Message/Transfers/ListTransfersRequestTest.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace Omnipay\Stripe\Message\Transfers;
+
+use Guzzle\Http\Message\Response;
+use Omnipay\Tests\TestCase;
+
+class ListTransfersRequestTest extends TestCase
+{
+
+    /** @var  ListTransfersRequest */
+    protected $request;
+
+    public function setUp()
+    {
+        $this->request = new ListTransfersRequest($this->getHttpClient(), $this->getHttpRequest());
+    }
+
+    public function testEndpoint()
+    {
+        $this->assertSame('https://api.stripe.com/v1/transfers', $this->request->getEndpoint());
+    }
+
+    public function testSendSuccess()
+    {
+        $this->setMockHttpResponse(
+            [Response::fromMessage(file_get_contents(__DIR__ . '/../../Mock/Transfers/ListTransfersSuccess.txt'))]
+        );
+
+        /** @var \Omnipay\Stripe\Message\Response $response */
+        $response = $this->request->send();
+
+        $data = $response->getData();
+
+        $this->assertTrue($response->isSuccessful());
+        $this->assertNotNull($response->getList());
+        $this->assertNull($response->getMessage());
+        $this->assertSame('/v1/transfers', $data['url']);
+        $this->assertFalse($response->isRedirect());
+    }
+
+    public function testSendFailure()
+    {
+        $this->request->setTransferGroup('NOTFOUND');
+
+        $this->setMockHttpResponse(
+            [Response::fromMessage(file_get_contents(__DIR__ . '/../../Mock/Transfers/ListTransfersFailure.txt'))]
+        );
+        $response = $this->request->send();
+
+        $this->assertFalse($response->isSuccessful());
+        $this->assertFalse($response->isRedirect());
+        $this->assertSame('No such transfer group: NOTFOUND', $response->getMessage());
+    }
+}

--- a/tests/Message/Transfers/ListTransfersRequestTest.php
+++ b/tests/Message/Transfers/ListTransfersRequestTest.php
@@ -24,7 +24,7 @@ class ListTransfersRequestTest extends TestCase
     public function testSendSuccess()
     {
         $this->setMockHttpResponse(
-            [Response::fromMessage(file_get_contents(__DIR__ . '/../../Mock/Transfers/ListTransfersSuccess.txt'))]
+            array(Response::fromMessage(file_get_contents(__DIR__.'/../../Mock/Transfers/ListTransfersSuccess.txt')))
         );
 
         /** @var \Omnipay\Stripe\Message\Response $response */
@@ -44,7 +44,7 @@ class ListTransfersRequestTest extends TestCase
         $this->request->setTransferGroup('NOTFOUND');
 
         $this->setMockHttpResponse(
-            [Response::fromMessage(file_get_contents(__DIR__ . '/../../Mock/Transfers/ListTransfersFailure.txt'))]
+            array(Response::fromMessage(file_get_contents(__DIR__.'/../../Mock/Transfers/ListTransfersFailure.txt')))
         );
         $response = $this->request->send();
 

--- a/tests/Message/Transfers/UpdateTransferRequestTest.php
+++ b/tests/Message/Transfers/UpdateTransferRequestTest.php
@@ -8,12 +8,18 @@ use Omnipay\Tests\TestCase;
 class UpdateTransferRequestTest extends TestCase
 {
     /**
-     * @var \Omnipay\Stripe\Message\Transfers\UpdateTransferRequest
+     * @var UpdateTransferRequest
      */
-    private $request;
+    protected $request;
+
+    /**
+     * @var string
+     */
+    protected $mockDir;
 
     public function setUp()
     {
+        $this->mockDir = __DIR__.'/../../Mock/Transfers';
         $this->request = new UpdateTransferRequest($this->getHttpClient(), $this->getHttpRequest());
         $this->request->setTransferReference('tr_164xRv2eZvKYlo2CZxJZWm1E');
     }
@@ -39,7 +45,7 @@ class UpdateTransferRequestTest extends TestCase
     public function testSendSuccess()
     {
         $this->setMockHttpResponse(
-            array(Response::fromMessage(file_get_contents(__DIR__.'/../../Mock/Transfers/CreateTransferRequestSuccess.txt')))
+            array(Response::fromMessage(file_get_contents($this->mockDir.'/CreateTransferRequestSuccess.txt')))
         );
         /** @var \Omnipay\Stripe\Message\Response $response */
         $response = $this->request->send();
@@ -53,7 +59,7 @@ class UpdateTransferRequestTest extends TestCase
     public function testSendFailure()
     {
         $this->setMockHttpResponse(
-            array(Response::fromMessage(file_get_contents(__DIR__.'/../../Mock/Transfers/FetchTransferFailure.txt')))
+            array(Response::fromMessage(file_get_contents($this->mockDir.'/FetchTransferFailure.txt')))
         );
         $response = $this->request->send();
 

--- a/tests/Message/Transfers/UpdateTransferRequestTest.php
+++ b/tests/Message/Transfers/UpdateTransferRequestTest.php
@@ -20,12 +20,15 @@ class UpdateTransferRequestTest extends TestCase
 
     public function testEndpoint()
     {
-        $this->assertSame('https://api.stripe.com/v1/transfers/tr_164xRv2eZvKYlo2CZxJZWm1E', $this->request->getEndpoint());
+        $this->assertSame(
+            'https://api.stripe.com/v1/transfers/tr_164xRv2eZvKYlo2CZxJZWm1E',
+            $this->request->getEndpoint()
+        );
     }
 
     public function testData()
     {
-        $this->request->setMetadata(['field' => 'value']);
+        $this->request->setMetadata(array('field' => 'value'));
 
         $data = $this->request->getData();
 
@@ -36,7 +39,7 @@ class UpdateTransferRequestTest extends TestCase
     public function testSendSuccess()
     {
         $this->setMockHttpResponse(
-            [Response::fromMessage(file_get_contents(__DIR__ . '/../../Mock/Transfers/CreateTransferRequestSuccess.txt'))]
+            array(Response::fromMessage(file_get_contents(__DIR__.'/../../Mock/Transfers/CreateTransferRequestSuccess.txt')))
         );
         /** @var \Omnipay\Stripe\Message\Response $response */
         $response = $this->request->send();
@@ -50,7 +53,7 @@ class UpdateTransferRequestTest extends TestCase
     public function testSendFailure()
     {
         $this->setMockHttpResponse(
-            [Response::fromMessage(file_get_contents(__DIR__ . '/../../Mock/Transfers/FetchTransferFailure.txt'))]
+            array(Response::fromMessage(file_get_contents(__DIR__.'/../../Mock/Transfers/FetchTransferFailure.txt')))
         );
         $response = $this->request->send();
 

--- a/tests/Message/Transfers/UpdateTransferRequestTest.php
+++ b/tests/Message/Transfers/UpdateTransferRequestTest.php
@@ -1,0 +1,61 @@
+<?php
+
+namespace Omnipay\Stripe\Message\Transfers;
+
+use Guzzle\Http\Message\Response;
+use Omnipay\Tests\TestCase;
+
+class UpdateTransferRequestTest extends TestCase
+{
+    /**
+     * @var \Omnipay\Stripe\Message\Transfers\UpdateTransferRequest
+     */
+    private $request;
+
+    public function setUp()
+    {
+        $this->request = new UpdateTransferRequest($this->getHttpClient(), $this->getHttpRequest());
+        $this->request->setTransferReference('tr_164xRv2eZvKYlo2CZxJZWm1E');
+    }
+
+    public function testEndpoint()
+    {
+        $this->assertSame('https://api.stripe.com/v1/transfers/tr_164xRv2eZvKYlo2CZxJZWm1E', $this->request->getEndpoint());
+    }
+
+    public function testData()
+    {
+        $this->request->setMetadata(['field' => 'value']);
+
+        $data = $this->request->getData();
+
+        $this->assertArrayHasKey('field', $data['metadata']);
+        $this->assertSame('value', $data['metadata']['field']);
+    }
+
+    public function testSendSuccess()
+    {
+        $this->setMockHttpResponse(
+            [Response::fromMessage(file_get_contents(__DIR__ . '/../../Mock/Transfers/CreateTransferRequestSuccess.txt'))]
+        );
+        /** @var \Omnipay\Stripe\Message\Response $response */
+        $response = $this->request->send();
+
+        $this->assertTrue($response->isSuccessful());
+        $this->assertFalse($response->isRedirect());
+        $this->assertSame('tr_164xRv2eZvKYlo2CZxJZWm1E', $response->getTransferReference());
+        $this->assertNull($response->getMessage());
+    }
+
+    public function testSendFailure()
+    {
+        $this->setMockHttpResponse(
+            [Response::fromMessage(file_get_contents(__DIR__ . '/../../Mock/Transfers/FetchTransferFailure.txt'))]
+        );
+        $response = $this->request->send();
+
+        $this->assertFalse($response->isSuccessful());
+        $this->assertFalse($response->isRedirect());
+        $this->assertSame('No such transfer: tr_164xRv2eZvKYlo2CZxJZWm1E', $response->getMessage());
+    }
+}

--- a/tests/Message/Transfers/UpdateTransferReversalRequestTest.php
+++ b/tests/Message/Transfers/UpdateTransferReversalRequestTest.php
@@ -8,12 +8,18 @@ use Omnipay\Tests\TestCase;
 class UpdateTransferReversalRequestTest extends TestCase
 {
     /**
-     * @var \Omnipay\Stripe\Message\Transfers\UpdateTransferRequest
+     * @var UpdateTransferReversalRequest
      */
-    private $request;
+    protected $request;
+
+    /**
+     * @var string
+     */
+    protected $mockDir;
 
     public function setUp()
     {
+        $this->mockDir = __DIR__.'/../../Mock/Transfers';
         $this->request = new UpdateTransferReversalRequest($this->getHttpClient(), $this->getHttpRequest());
         $this->request->setTransferReference('tr_164xRv2eZvKYlo2CZxJZWm1E');
         $this->request->setReversalReference('trr_1ARKQ22eZvKYlo2Cv5APdtKF');
@@ -42,7 +48,7 @@ class UpdateTransferReversalRequestTest extends TestCase
     public function testSendSuccess()
     {
         $this->setMockHttpResponse(
-            array(Response::fromMessage(file_get_contents(__DIR__.'/../../Mock/Transfers/CreateTransferReversalRequestSuccess.txt')))
+            array(Response::fromMessage(file_get_contents($this->mockDir.'/CreateTransferReversalRequestSuccess.txt')))
         );
         /** @var \Omnipay\Stripe\Message\Response $response */
         $response = $this->request->send();
@@ -56,7 +62,7 @@ class UpdateTransferReversalRequestTest extends TestCase
     public function testSendFailure()
     {
         $this->setMockHttpResponse(
-            array(Response::fromMessage(file_get_contents(__DIR__.'/../../Mock/Transfers/FetchTransferReversalFailure.txt')))
+            array(Response::fromMessage(file_get_contents($this->mockDir.'/FetchTransferReversalFailure.txt')))
         );
         $response = $this->request->send();
 

--- a/tests/Message/Transfers/UpdateTransferReversalRequestTest.php
+++ b/tests/Message/Transfers/UpdateTransferReversalRequestTest.php
@@ -1,0 +1,67 @@
+<?php
+
+namespace Omnipay\Stripe\Message\Transfers;
+
+use Guzzle\Http\Message\Response;
+use Omnipay\Tests\TestCase;
+
+class UpdateTransferReversalRequestTest extends TestCase
+{
+    /**
+     * @var \Omnipay\Stripe\Message\Transfers\UpdateTransferRequest
+     */
+    private $request;
+
+    public function setUp()
+    {
+        $this->request = new UpdateTransferReversalRequest($this->getHttpClient(), $this->getHttpRequest());
+        $this->request->setTransferReference('tr_164xRv2eZvKYlo2CZxJZWm1E');
+        $this->request->setReversalReference('trr_1ARKQ22eZvKYlo2Cv5APdtKF');
+    }
+
+    public function testEndpoint()
+    {
+        $this->assertSame(
+            'https://api.stripe.com/v1/transfers/tr_164xRv2eZvKYlo2CZxJZWm1E/reversals/trr_1ARKQ22eZvKYlo2Cv5APdtKF',
+            $this->request->getEndpoint()
+        );
+    }
+
+    public function testData()
+    {
+        $this->request->setMetadata(['field' => 'value']);
+        $this->request->setDescription('This is a reversal becuase of that');
+
+        $data = $this->request->getData();
+
+        $this->assertSame('This is a reversal becuase of that', $data['description']);
+        $this->assertArrayHasKey('field', $data['metadata']);
+        $this->assertSame('value', $data['metadata']['field']);
+    }
+
+    public function testSendSuccess()
+    {
+        $this->setMockHttpResponse(
+            [Response::fromMessage(file_get_contents(__DIR__ . '/../../Mock/Transfers/CreateTransferReversalRequestSuccess.txt'))]
+        );
+        /** @var \Omnipay\Stripe\Message\Response $response */
+        $response = $this->request->send();
+
+        $this->assertTrue($response->isSuccessful());
+        $this->assertFalse($response->isRedirect());
+        $this->assertSame('trr_1ARKQ22eZvKYlo2Cv5APdtKF', $response->getTransferReversalReference());
+        $this->assertNull($response->getMessage());
+    }
+
+    public function testSendFailure()
+    {
+        $this->setMockHttpResponse(
+            [Response::fromMessage(file_get_contents(__DIR__ . '/../../Mock/Transfers/FetchTransferReversalFailure.txt'))]
+        );
+        $response = $this->request->send();
+
+        $this->assertFalse($response->isSuccessful());
+        $this->assertFalse($response->isRedirect());
+        $this->assertSame('No such transfer reversal: trr_1ARKQ22eZvKYlo2Cv5APdtKF', $response->getMessage());
+    }
+}

--- a/tests/Message/Transfers/UpdateTransferReversalRequestTest.php
+++ b/tests/Message/Transfers/UpdateTransferReversalRequestTest.php
@@ -29,7 +29,7 @@ class UpdateTransferReversalRequestTest extends TestCase
 
     public function testData()
     {
-        $this->request->setMetadata(['field' => 'value']);
+        $this->request->setMetadata(array('field' => 'value'));
         $this->request->setDescription('This is a reversal becuase of that');
 
         $data = $this->request->getData();
@@ -42,7 +42,7 @@ class UpdateTransferReversalRequestTest extends TestCase
     public function testSendSuccess()
     {
         $this->setMockHttpResponse(
-            [Response::fromMessage(file_get_contents(__DIR__ . '/../../Mock/Transfers/CreateTransferReversalRequestSuccess.txt'))]
+            array(Response::fromMessage(file_get_contents(__DIR__.'/../../Mock/Transfers/CreateTransferReversalRequestSuccess.txt')))
         );
         /** @var \Omnipay\Stripe\Message\Response $response */
         $response = $this->request->send();
@@ -56,7 +56,7 @@ class UpdateTransferReversalRequestTest extends TestCase
     public function testSendFailure()
     {
         $this->setMockHttpResponse(
-            [Response::fromMessage(file_get_contents(__DIR__ . '/../../Mock/Transfers/FetchTransferReversalFailure.txt'))]
+            array(Response::fromMessage(file_get_contents(__DIR__.'/../../Mock/Transfers/FetchTransferReversalFailure.txt')))
         );
         $response = $this->request->send();
 

--- a/tests/Mock/Transfers/CreateTransferRequestFailure.txt
+++ b/tests/Mock/Transfers/CreateTransferRequestFailure.txt
@@ -1,0 +1,16 @@
+HTTP/1.1 402 Request Failed
+Server: nginx
+Date: Fri, 12 Feb 2016 20:48:09 GMT
+Content-Type: application/json
+Content-Length: 115
+Connection: keep-alive
+Access-Control-Allow-Credentials: true
+Access-Control-Max-Age: 300
+Cache-Control: no-cache, no-store
+
+{
+  "error": {
+    "type": "insufficient_funds",
+    "message": "Transfer does not have available funds"
+  }
+}

--- a/tests/Mock/Transfers/CreateTransferRequestSuccess.txt
+++ b/tests/Mock/Transfers/CreateTransferRequestSuccess.txt
@@ -1,0 +1,46 @@
+HTTP/1.1 200 OK
+Server: nginx
+Date: Mon, 01 Feb 2016 00:44:38 GMT
+Content-Type: application/json
+Content-Length: 1818
+Connection: keep-alive
+Access-Control-Allow-Credentials: true
+Cache-Control: no-cache, no-store
+
+{
+  "id": "tr_164xRv2eZvKYlo2CZxJZWm1E",
+  "object": "transfer",
+  "amount": 200,
+  "amount_reversed": 100,
+  "balance_transaction": "txn_19XJJ02eZvKYlo2ClwuJ1rbA",
+  "created": 1432229235,
+  "currency": "usd",
+  "destination": "acct_164wxjKbnvuxQXGu",
+  "destination_payment": "py_164xRvKbnvuxQXGuVFV2pZo1",
+  "livemode": false,
+  "metadata": {
+  },
+  "reversals": {
+    "object": "list",
+    "data": [
+      {
+        "id": "trr_1AF3y32eZvKYlo2CtkDXeobp",
+        "object": "transfer_reversal",
+        "amount": 100,
+        "balance_transaction": "txn_1AF3y32eZvKYlo2CSgDInbEk",
+        "created": 1493742915,
+        "currency": "usd",
+        "metadata": {
+        },
+        "transfer": "tr_164xRv2eZvKYlo2CZxJZWm1E"
+      }
+    ],
+    "has_more": false,
+    "total_count": 1,
+    "url": "/v1/transfers/tr_164xRv2eZvKYlo2CZxJZWm1E/reversals"
+  },
+  "reversed": false,
+  "source_transaction": "ch_164xRv2eZvKYlo2Clu1sIJWB",
+  "source_type": "card",
+  "transfer_group": "group_ch_164xRv2eZvKYlo2Clu1sIJWB"
+}

--- a/tests/Mock/Transfers/CreateTransferReversalRequestSuccess.txt
+++ b/tests/Mock/Transfers/CreateTransferReversalRequestSuccess.txt
@@ -1,0 +1,20 @@
+HTTP/1.1 200 OK
+Server: nginx
+Date: Mon, 01 Feb 2016 00:44:38 GMT
+Content-Type: application/json
+Content-Length: 1818
+Connection: keep-alive
+Access-Control-Allow-Credentials: true
+Cache-Control: no-cache, no-store
+
+{
+  "id": "trr_1ARKQ22eZvKYlo2Cv5APdtKF",
+  "object": "transfer_reversal",
+  "amount": 400,
+  "balance_transaction": "txn_1ARKQ22eZvKYlo2C76jP3q3o",
+  "created": 1496666090,
+  "currency": "usd",
+  "metadata": {
+  },
+  "transfer": "tr_1ARKPl2eZvKYlo2CsNTKWIOO"
+}

--- a/tests/Mock/Transfers/FetchTransferFailure.txt
+++ b/tests/Mock/Transfers/FetchTransferFailure.txt
@@ -1,0 +1,15 @@
+HTTP/1.1 404 Not Found
+Server: nginx
+Date: Sun, 21 Feb 2016 21:16:02 GMT
+Content-Type: application/json
+Content-Length: 143
+Connection: keep-alive
+Cache-Control: no-cache, no-store
+
+{
+  "error": {
+    "type": "invalid_request_error",
+    "message": "No such transfer: tr_164xRv2eZvKYlo2CZxJZWm1E",
+    "param": "id"
+  }
+}

--- a/tests/Mock/Transfers/FetchTransferReversalFailure.txt
+++ b/tests/Mock/Transfers/FetchTransferReversalFailure.txt
@@ -1,0 +1,15 @@
+HTTP/1.1 404 Not Found
+Server: nginx
+Date: Sun, 21 Feb 2016 21:16:02 GMT
+Content-Type: application/json
+Content-Length: 143
+Connection: keep-alive
+Cache-Control: no-cache, no-store
+
+{
+  "error": {
+    "type": "invalid_request_error",
+    "message": "No such transfer reversal: trr_1ARKQ22eZvKYlo2Cv5APdtKF",
+    "param": "id"
+  }
+}

--- a/tests/Mock/Transfers/FetchTransferReversalSuccess.txt
+++ b/tests/Mock/Transfers/FetchTransferReversalSuccess.txt
@@ -1,0 +1,21 @@
+HTTP/1.1 200 OK 
+Server: nginx 
+Date: Wed, 24 Jul 2013 07:14:02 GMT 
+Content-Type: application/json;charset=utf-8 
+Content-Length: 1092 
+Connection: keep-alive 
+Access-Control-Allow-Credentials: true 
+Access-Control-Max-Age: 300 
+Cache-Control: no-cache, no-store 
+
+{
+  "id": "trr_1ARKQ22eZvKYlo2Cv5APdtKF",
+  "object": "transfer_reversal",
+  "amount": 400,
+  "balance_transaction": "txn_19XJJ02eZvKYlo2ClwuJ1rbA",
+  "created": 1496666090,
+  "currency": "usd",
+  "metadata": {
+  },
+  "transfer": "tr_1ARKPl2eZvKYlo2CsNTKWIOO"
+}

--- a/tests/Mock/Transfers/FetchTransferSuccess.txt
+++ b/tests/Mock/Transfers/FetchTransferSuccess.txt
@@ -1,0 +1,47 @@
+HTTP/1.1 200 OK 
+Server: nginx 
+Date: Wed, 24 Jul 2013 07:14:02 GMT 
+Content-Type: application/json;charset=utf-8 
+Content-Length: 1092 
+Connection: keep-alive 
+Access-Control-Allow-Credentials: true 
+Access-Control-Max-Age: 300 
+Cache-Control: no-cache, no-store 
+
+{
+  "id": "tr_164xRv2eZvKYlo2CZxJZWm1E",
+  "object": "transfer",
+  "amount": 200,
+  "amount_reversed": 100,
+  "balance_transaction": "txn_19XJJ02eZvKYlo2ClwuJ1rbA",
+  "created": 1432229235,
+  "currency": "usd",
+  "destination": "acct_164wxjKbnvuxQXGu",
+  "destination_payment": "py_164xRvKbnvuxQXGuVFV2pZo1",
+  "livemode": false,
+  "metadata": {
+  },
+  "reversals": {
+    "object": "list",
+    "data": [
+      {
+        "id": "trr_1AF3y32eZvKYlo2CtkDXeobp",
+        "object": "transfer_reversal",
+        "amount": 100,
+        "balance_transaction": "txn_1AF3y32eZvKYlo2CSgDInbEk",
+        "created": 1493742915,
+        "currency": "usd",
+        "metadata": {
+        },
+        "transfer": "tr_164xRv2eZvKYlo2CZxJZWm1E"
+      }
+    ],
+    "has_more": false,
+    "total_count": 1,
+    "url": "/v1/transfers/tr_164xRv2eZvKYlo2CZxJZWm1E/reversals"
+  },
+  "reversed": false,
+  "source_transaction": "ch_164xRv2eZvKYlo2Clu1sIJWB",
+  "source_type": "card",
+  "transfer_group": "group_ch_164xRv2eZvKYlo2Clu1sIJWB"
+}

--- a/tests/Mock/Transfers/ListTransferReversalsFailure.txt
+++ b/tests/Mock/Transfers/ListTransferReversalsFailure.txt
@@ -1,0 +1,15 @@
+HTTP/1.1 404 Not Found
+Server: nginx
+Date: Sun, 21 Feb 2016 21:16:02 GMT
+Content-Type: application/json
+Content-Length: 143
+Connection: keep-alive
+Cache-Control: no-cache, no-store
+
+{
+  "error": {
+    "type": "invalid_request_error",
+    "message": "No such transfer: NOTFOUND",
+    "param": "id"
+  }
+}

--- a/tests/Mock/Transfers/ListTransferReversalsSuccess.txt
+++ b/tests/Mock/Transfers/ListTransferReversalsSuccess.txt
@@ -1,0 +1,38 @@
+HTTP/1.1 200 OK
+Server: nginx
+Date: Mon, 29 Feb 2016 02:40:46 GMT
+Content-Type: application/json
+Content-Length: 6247
+Connection: keep-alive
+Access-Control-Allow-Credentials: true
+Cache-Control: no-cache, no-store
+
+{
+  "object": "list",
+  "url": "/v1/transfers/tr_164xRv2eZvKYlo2CZxJZWm1E/reversals",
+  "has_more": false,
+  "data": [
+    {
+      "id": "trr_1ARKQ22eZvKYlo2Cv5APdtKF",
+      "object": "transfer_reversal",
+      "amount": 400,
+      "balance_transaction": "txn_19XJJ02eZvKYlo2ClwuJ1rbA",
+      "created": 1496666090,
+      "currency": "usd",
+      "metadata": {
+      },
+      "transfer": "tr_1ARKPl2eZvKYlo2CsNTKWIOO"
+    },
+    {
+      "id": "trr_2ARKQ22eZvKYlo2Cv5APdtKF",
+      "object": "transfer_reversal",
+      "amount": 400,
+      "balance_transaction": "txn_29XJJ02eZvKYlo2ClwuJ1rbA",
+      "created": 1596666090,
+      "currency": "usd",
+      "metadata": {
+      },
+      "transfer": "tr_2ARKPl2eZvKYlo2CsNTKWIOO"
+    }
+  ]
+}

--- a/tests/Mock/Transfers/ListTransfersFailure.txt
+++ b/tests/Mock/Transfers/ListTransfersFailure.txt
@@ -1,0 +1,15 @@
+HTTP/1.1 404 Not Found
+Server: nginx
+Date: Sun, 21 Feb 2016 21:16:02 GMT
+Content-Type: application/json
+Content-Length: 143
+Connection: keep-alive
+Cache-Control: no-cache, no-store
+
+{
+  "error": {
+    "type": "invalid_request_error",
+    "message": "No such transfer group: NOTFOUND",
+    "param": "id"
+  }
+}

--- a/tests/Mock/Transfers/ListTransfersSuccess.txt
+++ b/tests/Mock/Transfers/ListTransfersSuccess.txt
@@ -1,0 +1,90 @@
+HTTP/1.1 200 OK
+Server: nginx
+Date: Mon, 29 Feb 2016 02:40:46 GMT
+Content-Type: application/json
+Content-Length: 6247
+Connection: keep-alive
+Access-Control-Allow-Credentials: true
+Cache-Control: no-cache, no-store
+
+{
+  "object": "list",
+  "url": "/v1/transfers",
+  "has_more": false,
+  "data": [
+    {
+      "id": "tr_164xRv2eZvKYlo2CZxJZWm1E",
+      "object": "transfer",
+      "amount": 200,
+      "amount_reversed": 100,
+      "balance_transaction": "txn_19XJJ02eZvKYlo2ClwuJ1rbA",
+      "created": 1432229235,
+      "currency": "usd",
+      "destination": "acct_164wxjKbnvuxQXGu",
+      "destination_payment": "py_164xRvKbnvuxQXGuVFV2pZo1",
+      "livemode": false,
+      "metadata": {
+      },
+      "reversals": {
+        "object": "list",
+        "data": [
+          {
+            "id": "trr_1AF3y32eZvKYlo2CtkDXeobp",
+            "object": "transfer_reversal",
+            "amount": 100,
+            "balance_transaction": "txn_1AF3y32eZvKYlo2CSgDInbEk",
+            "created": 1493742915,
+            "currency": "usd",
+            "metadata": {
+            },
+            "transfer": "tr_164xRv2eZvKYlo2CZxJZWm1E"
+          }
+        ],
+        "has_more": false,
+        "total_count": 1,
+        "url": "/v1/transfers/tr_164xRv2eZvKYlo2CZxJZWm1E/reversals"
+      },
+      "reversed": false,
+      "source_transaction": "ch_164xRv2eZvKYlo2Clu1sIJWB",
+      "source_type": "card",
+      "transfer_group": "group_ch_164xRv2eZvKYlo2Clu1sIJWB"
+    },
+    {
+      "id": "tr_164xRv2DKDJF832CZxJZWm1E",
+      "object": "transfer",
+      "amount": 250,
+      "amount_reversed": 100,
+      "balance_transaction": "txn_19XJJ02JDKDo2ClwuJ1rbA",
+      "created": 1432429235,
+      "currency": "usd",
+      "destination": "acct_164wxjKbnvuxQXGu",
+      "destination_payment": "py_164xRvKbnvuxKDUD3dVFV2pZo1",
+      "livemode": false,
+      "metadata": {
+      },
+      "reversals": {
+        "object": "list",
+        "data": [
+          {
+            "id": "trr_1AF3KDjdkddeZvKYlo2CtkDXeobp",
+            "object": "transfer_reversal",
+            "amount": 100,
+            "balance_transaction": "txn_DF8d3y32eZvKYlo2CSgDInbEk",
+            "created": 1492429235,
+            "currency": "usd",
+            "metadata": {
+            },
+            "transfer": "tr_164xRv2DKDJF832CZxJZWm1E"
+          }
+        ],
+        "has_more": false,
+        "total_count": 1,
+        "url": "/v1/transfers/tr_164xRv2DKDJF832CZxJZWm1E/reversals"
+      },
+      "reversed": false,
+      "source_transaction": "ch_264xDJD83ZvKYlo2Clu1sIJWB",
+      "source_type": "card",
+      "transfer_group": "group_ch_264xRv2eZvKYlo2Clu1sIJWB"
+    }
+  ]
+}


### PR DESCRIPTION
Adds the ability to create Stripe Connect charges and transfers based on https://stripe.com/docs/connect/charges
References #78, #70

This PR also adds support for Stripe's Idempotent Requests https://stripe.com/docs/api#idempotent_requests
Reference #33
