### PR TITLE
Add metadata to CreateSubscriptionRequest (fixes #60, #73)

### DIFF
--- a/src/Message/CreateSubscriptionRequest.php
+++ b/src/Message/CreateSubscriptionRequest.php
@@ -65,6 +65,10 @@ class CreateSubscriptionRequest extends AbstractRequest
             $data['tax_percent'] = (float)$this->getParameter('tax_percent');
         }
 
+        if ($this->getMetadata()) {
+            $data['metadata'] = $this->getMetadata();
+        }
+
         return $data;
     }
 

--- a/src/Message/CreateSubscriptionRequest.php
+++ b/src/Message/CreateSubscriptionRequest.php
@@ -3,18 +3,19 @@
 /**
  * Stripe Create Subscription Request.
  */
+
 namespace Omnipay\Stripe\Message;
 
 /**
  * Stripe Create Subscription Request
  *
- * @see Omnipay\Stripe\Gateway
+ * @see \Omnipay\Stripe\Gateway
  * @link https://stripe.com/docs/api/php#create_subscription
  */
 class CreateSubscriptionRequest extends AbstractRequest
 {
     /**
-     * Get the plan ID
+     * Get the plan
      *
      * @return string
      */
@@ -24,9 +25,10 @@ class CreateSubscriptionRequest extends AbstractRequest
     }
 
     /**
-     * Set the plan ID
+     * Set the plan
      *
-     * @return CreateSubscriptionRequest provides a fluent interface.
+     * @param $value
+     * @return \Omnipay\Common\Message\AbstractRequest|CreateSubscriptionRequest
      */
     public function setPlan($value)
     {
@@ -46,7 +48,8 @@ class CreateSubscriptionRequest extends AbstractRequest
     /**
      * Set the tax percentage
      *
-     * @return CreateSubscriptionRequest provides a fluent interface.
+     * @param $value
+     * @return \Omnipay\Common\Message\AbstractRequest|CreateSubscriptionRequest
      */
     public function setTaxPercent($value)
     {

--- a/src/Message/FetchSubscriptionRequest.php
+++ b/src/Message/FetchSubscriptionRequest.php
@@ -3,6 +3,7 @@
 /**
  * Stripe Fetch Subscription Request.
  */
+
 namespace Omnipay\Stripe\Message;
 
 /**
@@ -25,7 +26,8 @@ class FetchSubscriptionRequest extends AbstractRequest
     /**
      * Set the subscription reference.
      *
-     * @return FetchSubscriptionRequest provides a fluent interface.
+     * @param $value
+     * @return \Omnipay\Common\Message\AbstractRequest|FetchSubscriptionRequest
      */
     public function setSubscriptionReference($value)
     {
@@ -35,15 +37,14 @@ class FetchSubscriptionRequest extends AbstractRequest
     public function getData()
     {
         $this->validate('customerReference', 'subscriptionReference');
-        $data = array();
 
-        return $data;
+        return array();
     }
 
     public function getEndpoint()
     {
         return $this->endpoint.'/customers/'.$this->getCustomerReference()
-                                .'/subscriptions/'.$this->getSubscriptionReference();
+            .'/subscriptions/'.$this->getSubscriptionReference();
     }
 
     public function getHttpMethod()

--- a/src/Message/UpdateSubscriptionRequest.php
+++ b/src/Message/UpdateSubscriptionRequest.php
@@ -36,6 +36,24 @@ class UpdateSubscriptionRequest extends AbstractRequest
     }
 
     /**
+     * @deprecated
+     */
+    public function getPlanId()
+    {
+        return $this->getPlan();
+    }
+
+    /**
+     * @deprecated
+     * @param $value
+     * @return \Omnipay\Common\Message\AbstractRequest|UpdateSubscriptionRequest
+     */
+    public function setPlanId($value)
+    {
+        return $this->setPlan($value);
+    }
+    
+    /**
      * Get the subscription reference
      *
      * @return string

--- a/src/Message/UpdateSubscriptionRequest.php
+++ b/src/Message/UpdateSubscriptionRequest.php
@@ -52,7 +52,7 @@ class UpdateSubscriptionRequest extends AbstractRequest
     {
         return $this->setPlan($value);
     }
-    
+
     /**
      * Get the subscription reference
      *

--- a/src/Message/UpdateSubscriptionRequest.php
+++ b/src/Message/UpdateSubscriptionRequest.php
@@ -14,21 +14,22 @@ namespace Omnipay\Stripe\Message;
 class UpdateSubscriptionRequest extends AbstractRequest
 {
     /**
-     * Get the plan ID
+     * Get the plan
      *
      * @return string
      */
-    public function getPlanId()
+    public function getPlan()
     {
         return $this->getParameter('plan');
     }
 
     /**
-     * Set the plan ID
+     * Set the plan
      *
-     * @return UpdateSubscriptionRequest provides a fluent interface.
+     * @param $value
+     * @return \Omnipay\Common\Message\AbstractRequest|UpdateSubscriptionRequest
      */
-    public function setPlanId($value)
+    public function setPlan($value)
     {
         return $this->setParameter('plan', $value);
     }
@@ -58,7 +59,7 @@ class UpdateSubscriptionRequest extends AbstractRequest
         $this->validate('customerReference', 'subscriptionReference', 'plan');
 
         $data = array(
-            'plan' => $this->getPlanId()
+            'plan' => $this->getPlan()
         );
 
         return $data;

--- a/src/Message/UpdateSubscriptionRequest.php
+++ b/src/Message/UpdateSubscriptionRequest.php
@@ -3,12 +3,13 @@
 /**
  * Stripe Update Subscription Request.
  */
+
 namespace Omnipay\Stripe\Message;
 
 /**
  * Stripe Update Subscription Request
  *
- * @see Omnipay\Stripe\Gateway
+ * @see \Omnipay\Stripe\Gateway
  * @link https://stripe.com/docs/api#update_subscription
  */
 class UpdateSubscriptionRequest extends AbstractRequest
@@ -35,16 +36,6 @@ class UpdateSubscriptionRequest extends AbstractRequest
     }
 
     /**
-     * Set the subscription reference
-     *
-     * @return UpdateSubscriptionRequest provides a fluent interface.
-     */
-    public function setSubscriptionReference($value)
-    {
-        return $this->setParameter('subscriptionReference', $value);
-    }
-
-    /**
      * Get the subscription reference
      *
      * @return string
@@ -52,6 +43,17 @@ class UpdateSubscriptionRequest extends AbstractRequest
     public function getSubscriptionReference()
     {
         return $this->getParameter('subscriptionReference');
+    }
+
+    /**
+     * Set the subscription reference
+     *
+     * @param $value
+     * @return \Omnipay\Common\Message\AbstractRequest|UpdateSubscriptionRequest
+     */
+    public function setSubscriptionReference($value)
+    {
+        return $this->setParameter('subscriptionReference', $value);
     }
 
     public function getData()
@@ -62,12 +64,20 @@ class UpdateSubscriptionRequest extends AbstractRequest
             'plan' => $this->getPlan()
         );
 
+        if ($this->parameters->has('tax_percent')) {
+            $data['tax_percent'] = (float)$this->getParameter('tax_percent');
+        }
+
+        if ($this->getMetadata()) {
+            $data['metadata'] = $this->getMetadata();
+        }
+
         return $data;
     }
 
     public function getEndpoint()
     {
         return $this->endpoint.'/customers/'.$this->getCustomerReference()
-                .'/subscriptions/'.$this->getSubscriptionReference();
+            .'/subscriptions/'.$this->getSubscriptionReference();
     }
 }

--- a/tests/Message/CreateSubscriptionRequestTest.php
+++ b/tests/Message/CreateSubscriptionRequestTest.php
@@ -6,6 +6,9 @@ use Omnipay\Tests\TestCase;
 
 class CreateSubscriptionRequestTest extends TestCase
 {
+    /** @var CreateSubscriptionRequest */
+    protected $request;
+
     public function setUp()
     {
         $this->request = new CreateSubscriptionRequest($this->getHttpClient(), $this->getHttpRequest());
@@ -13,9 +16,42 @@ class CreateSubscriptionRequestTest extends TestCase
         $this->request->setPlan('basic');
     }
 
+    public function testData()
+    {
+        $this->request->setTaxPercent(14);
+        $this->request->setMetadata(array('field' => 'value'));
+
+        $data = $this->request->getData();
+
+        $this->assertSame(14.0, $data['tax_percent']);
+        $this->assertArrayHasKey('field', $data['metadata']);
+        $this->assertSame('value', $data['metadata']['field']);
+    }
+
+    public function testZeroPercentData()
+    {
+        $this->request->setTaxPercent(0);
+
+        $data = $this->request->getData();
+
+        $this->assertSame(0.0, $data['tax_percent']);
+    }
+
+    public function testZeroPercentStringData()
+    {
+        $this->request->setTaxPercent('0');
+
+        $data = $this->request->getData();
+
+        $this->assertSame(0.0, $data['tax_percent']);
+    }
+
     public function testEndpoint()
     {
-        $this->assertSame('https://api.stripe.com/v1/customers/cus_7lqqgOm33t4xSU/subscriptions', $this->request->getEndpoint());
+        $this->assertSame(
+            'https://api.stripe.com/v1/customers/cus_7lqqgOm33t4xSU/subscriptions',
+            $this->request->getEndpoint()
+        );
     }
 
     public function testSendSuccess()

--- a/tests/Message/UpdateSubscriptionRequestTest.php
+++ b/tests/Message/UpdateSubscriptionRequestTest.php
@@ -6,12 +6,17 @@ use Omnipay\Tests\TestCase;
 
 class UpdateSubscriptionRequestTest extends TestCase
 {
+    /**
+     * @var UpdateSubscriptionRequest
+     */
+    protected $request;
+
     public function setUp()
     {
         $this->request = new UpdateSubscriptionRequest($this->getHttpClient(), $this->getHttpRequest());
         $this->request->setCustomerReference('cus_7lqqgOm33t4xSU');
         $this->request->setSubscriptionReference('sub_7uNSBwlTzGjYWw');
-        $this->request->setPlanId('basic');
+        $this->request->setPlan('basic');
     }
 
     public function testEndpoint()
@@ -23,7 +28,9 @@ class UpdateSubscriptionRequestTest extends TestCase
     public function testSendSuccess()
     {
         $this->setMockHttpResponse('UpdateSubscriptionSuccess.txt');
+        /** @var Response */
         $response = $this->request->send();
+
         $this->assertTrue($response->isSuccessful());
         $this->assertFalse($response->isRedirect());
         $this->assertSame('sub_7uNSBwlTzGjYWw', $response->getSubscriptionReference());
@@ -35,14 +42,22 @@ class UpdateSubscriptionRequestTest extends TestCase
     public function testSendError()
     {
         $this->setMockHttpResponse('UpdateSubscriptionFailure.txt');
+
+        /** @var Response */
         $response = $this->request->send();
         $this->assertFalse($response->isSuccessful());
         $this->assertFalse($response->isRedirect());
         $this->assertNull($response->getSubscriptionReference());
         $this->assertNull($response->getPlan());
-        $c = $this->request->getCustomerReference();
-        $s = $this->request->getSubscriptionReference();
-        $message = sprintf('Customer %s does not have a subscription with ID %s', $c, $s);
+
+        $customerReference = $this->request->getCustomerReference();
+        $subscriptionReference = $this->request->getSubscriptionReference();
+
+        $message = sprintf(
+            'Customer %s does not have a subscription with ID %s',
+            $customerReference,
+            $subscriptionReference
+        );
         $this->assertSame($message, $response->getMessage());
     }
 }


### PR DESCRIPTION
Metadata wasn't being sent with the `CreateSubscriptionRequest`. This fixes that.