### PR TITLE
Allow using customerReference to list only invoices from a specific c…

### DIFF
--- a/src/Message/ListInvoicesRequest.php
+++ b/src/Message/ListInvoicesRequest.php
@@ -22,7 +22,12 @@ class ListInvoicesRequest extends AbstractRequest
 
     public function getEndpoint()
     {
-        return $this->endpoint.'/invoices';
+        $endpoint = $this->endpoint.'/invoices';
+        if ($customerReference = $this->getCustomerReference()) {
+            return $endpoint . '?customer=' . $customerReference;
+        }
+
+        return $endpoint;
     }
 
     public function getHttpMethod()

--- a/tests/Message/ListInvoicesRequestTest.php
+++ b/tests/Message/ListInvoicesRequestTest.php
@@ -37,4 +37,39 @@ class ListInvoicesRequestTest extends TestCase
         $this->assertNull($response->getList());
         $this->assertSame('Invalid API Key provided: sk_test_1234567890ABCDEFlfQ0', $response->getMessage());
     }
+
+    public function testEndpointWithCustomerReference()
+    {
+        $this->request->setCustomerReference('cus_7zdKilofy4RbZk');
+        $this->assertSame('https://api.stripe.com/v1/invoices?customer=cus_7zdKilofy4RbZk', $this->request->getEndpoint());
+    }
+
+    public function testSendWithCustomerReferenceSuccess()
+    {
+        $this->setMockHttpResponse('ListInvoicesSuccess.txt');
+        $this->request->setCustomerReference('cus_7zdKilofy4RbZk');
+        $response = $this->request->send();
+
+        $this->assertTrue($response->isSuccessful());
+        $this->assertFalse($response->isRedirect());
+        $this->assertNotNull($response->getList());
+        $this->assertNull($response->getMessage());
+
+        $invoices = $response->getList();
+        $this->assertSame('cus_7zdKilofy4RbZk', $invoices[0]['customer']);
+
+    }
+
+    public function testSendWithCustomerReferenceFailure()
+    {
+        $this->setMockHttpResponse('ListInvoicesWithCustomerReferenceFailure.txt');
+        $this->request->setCustomerReference('cus_1MZSEtqSghKx99');
+        $response = $this->request->send();
+
+        $this->assertFalse($response->isSuccessful());
+        $this->assertFalse($response->isRedirect());
+        $this->assertNull($response->getList());
+        $this->assertSame('No such customer: cus_1MZSEtqSghKx99', $response->getMessage());
+    }
+
 }

--- a/tests/Mock/ListInvoicesWithCustomerReferenceFailure.txt
+++ b/tests/Mock/ListInvoicesWithCustomerReferenceFailure.txt
@@ -1,0 +1,17 @@
+HTTP/1.1 404 Not Found
+Server: nginx
+Date: Tue, 26 Feb 2013 16:32:51 GMT
+Content-Type: application/json;charset=utf-8
+Content-Length: 131
+Connection: keep-alive
+Access-Control-Max-Age: 300
+Access-Control-Allow-Credentials: true
+Cache-Control: no-cache, no-store
+
+{
+  "error": {
+    "type": "invalid_request_error",
+    "message": "No such customer: cus_1MZSEtqSghKx99",
+    "param": "customer"
+  }
+}


### PR DESCRIPTION
Stripe allows listing invoices by a specific customer.  This pull request passes the customerReference as a query argument to the endpoint so that only invoices from the specified customer are returned