### PR TITLE
Create Tokens - Connect API

### DIFF
--- a/src/Message/CreateTokenRequest.php
+++ b/src/Message/CreateTokenRequest.php
@@ -51,7 +51,7 @@ class CreateTokenRequest extends AbstractRequest
      */
     public function getData()
     {
-        $data = [];
+        $data = array();
 
         if ($this->getParameter('customer')) {
             $data['customer'] = $this->getParameter('customer');

--- a/src/Message/CreateTokenRequest.php
+++ b/src/Message/CreateTokenRequest.php
@@ -1,0 +1,76 @@
+<?php
+
+
+namespace Omnipay\Stripe\Message;
+
+use Omnipay\Common\Exception\InvalidRequestException;
+
+/**
+ * Message which creates a new card token, or in a Connect API
+ * workflow can be used to share clients between the platform and
+ * the connected accounts.
+ *
+ * Creates a single use token that wraps the details of a credit card.
+ * This token can be used in place of a credit card dictionary with any API method.
+ * These tokens can only be used once: by creating a new charge object, or attaching them to a customer.
+ *
+ * In most cases, you should create tokens client-side using Checkout, Elements, or our mobile libraries,
+ * instead of using the API.
+ *
+ * @link https://stripe.com/docs/api#create_card_token
+ */
+class CreateTokenRequest extends AbstractRequest
+{
+    /**
+     * @inheritdoc
+     *
+     * @param \Omnipay\Common\CreditCard $value Credit card object
+     * @return \Omnipay\Common\Message\AbstractRequest $this
+     */
+    public function setCard($value)
+    {
+        return parent::setCard($value);
+    }
+
+    /**
+     * The id of the customer with format cus_<identifier>.
+     * <strong>Only use this if you are using Connect API</strong>
+     *
+     * @param string $customer The id of the customer
+     */
+    public function setCustomer($customer)
+    {
+        $this->setParameter('customer', $customer);
+    }
+
+    /**
+     * Get the raw data array for this message. The format of this varies from gateway to
+     * gateway, but will usually be either an associative array, or a SimpleXMLElement.
+     * @return mixed
+     * @throws InvalidRequestException
+     */
+    public function getData()
+    {
+        $data = [];
+
+        if ($this->getParameter('customer')) {
+            $data['customer'] = $this->getParameter('customer');
+        } else if ($this->getParameter('card')) {
+            $data['card'] = $this->getParameter('card');
+        } else {
+            throw new InvalidRequestException("You must pass either the card or the customer");
+        }
+
+        return $data;
+    }
+
+    /**
+     * @inheritdoc
+     *
+     * @return string The endpoint for the create token request.
+     */
+    public function getEndpoint()
+    {
+        return $this->endpoint . '/tokens';
+    }
+}

--- a/src/Message/CreateTokenRequest.php
+++ b/src/Message/CreateTokenRequest.php
@@ -55,7 +55,7 @@ class CreateTokenRequest extends AbstractRequest
 
         if ($this->getParameter('customer')) {
             $data['customer'] = $this->getParameter('customer');
-        } else if ($this->getParameter('card')) {
+        } elseif ($this->getParameter('card')) {
             $data['card'] = $this->getParameter('card');
         } else {
             throw new InvalidRequestException("You must pass either the card or the customer");

--- a/tests/Message/CreateTokenRequestTest.php
+++ b/tests/Message/CreateTokenRequestTest.php
@@ -9,7 +9,6 @@
 namespace Omnipay\Stripe\Message;
 
 
-use Omnipay\Common\Exception\InvalidRequestException;
 use Omnipay\Tests\TestCase;
 
 class CreateTokenRequestTest extends TestCase
@@ -70,11 +69,12 @@ class CreateTokenRequestTest extends TestCase
         $this->setMockHttpResponse('CreateTokenSuccess.txt');
         $response = $this->request->send();
 
+        $data = $response->getData();
         $this->assertTrue($response->isSuccessful());
         $this->assertFalse($response->isRedirect());
         $this->assertNull($response->getTransactionReference());
-        $this->assertSame('tok_1AWDl1JqXiFraDuL2xOKEXKy', $response->getData()['id']);
-        $this->assertSame('token', $response->getData()['object']);
+        $this->assertSame('tok_1AWDl1JqXiFraDuL2xOKEXKy', $data['id']);
+        $this->assertSame('token', $data['object']);
     }
 
 

--- a/tests/Message/CreateTokenRequestTest.php
+++ b/tests/Message/CreateTokenRequestTest.php
@@ -33,10 +33,12 @@ class CreateTokenRequestTest extends TestCase
         $this->assertSame('https://api.stripe.com/v1/tokens', $this->request->getEndpoint());
     }
 
+    /**
+     * @expectedException \Omnipay\Common\Exception\InvalidRequestException
+     * @expectedExceptionMessage You must pass either the card or the customer
+     */
     public function testGetDataInvalid()
     {
-        $this->setExpectedException(InvalidRequestException::class, "You must pass either the card or the customer");
-
         $this->request->setCustomer(null);
         $this->request->setCard(null);
 

--- a/tests/Message/CreateTokenRequestTest.php
+++ b/tests/Message/CreateTokenRequestTest.php
@@ -1,0 +1,79 @@
+<?php
+/**
+ * Created by PhpStorm.
+ * User: pedro
+ * Date: 18/06/17
+ * Time: 21:30
+ */
+
+namespace Omnipay\Stripe\Message;
+
+
+use Omnipay\Common\Exception\InvalidRequestException;
+use Omnipay\Tests\TestCase;
+
+class CreateTokenRequestTest extends TestCase
+{
+    /**
+     * @var CreateTokenRequest $request
+     */
+    private $request;
+
+    public function setUp()
+    {
+        parent::setUp();
+        $this->request = new CreateTokenRequest($this->getHttpClient(), $this->getHttpRequest());
+
+        $this->request->setCustomer('cus_example123');
+        $this->request->setConnectedStripeAccountHeader('acct_12oh2oi3');
+    }
+
+    public function testEndpoint()
+    {
+        $this->assertSame('https://api.stripe.com/v1/tokens', $this->request->getEndpoint());
+    }
+
+    public function testGetDataInvalid()
+    {
+        $this->setExpectedException(InvalidRequestException::class, "You must pass either the card or the customer");
+
+        $this->request->setCustomer(null);
+        $this->request->setCard(null);
+
+        $this->request->getData();
+    }
+
+    public function getDataWithCard()
+    {
+        $card = $this->getValidCard();
+        $this->request->setCard($card);
+
+        $data = $this->request->getData();
+
+        $this->assertSame($card['number'], $data['card']['number']);
+    }
+
+    public function testResponseFailure()
+    {
+        $this->setMockHttpResponse('CreateTokenFailure.txt');
+        $response = $this->request->send();
+
+        $this->assertFalse($response->isSuccessful());
+
+        $this->assertNull($response->getTransactionReference());
+    }
+
+    public function testResponseSuccess()
+    {
+        $this->setMockHttpResponse('CreateTokenSuccess.txt');
+        $response = $this->request->send();
+
+        $this->assertTrue($response->isSuccessful());
+        $this->assertFalse($response->isRedirect());
+        $this->assertNull($response->getTransactionReference());
+        $this->assertSame('tok_1AWDl1JqXiFraDuL2xOKEXKy', $response->getData()['id']);
+        $this->assertSame('token', $response->getData()['object']);
+    }
+
+
+}

--- a/tests/Mock/CreateTokenFailure.txt
+++ b/tests/Mock/CreateTokenFailure.txt
@@ -1,0 +1,22 @@
+HTTP/1.1 400 Bad Request
+Server: nginx
+Date: Mon, 19 Jun 2017 00:29:43 GMT
+Content-Type: application/json
+Content-Length: 140
+Connection: keep-alive
+Access-Control-Allow-Credentials: true
+Access-Control-Allow-Methods: GET, POST, HEAD, OPTIONS, DELETE
+Access-Control-Allow-Origin: *
+Access-Control-Max-Age: 300
+Cache-Control: no-cache, no-store
+Request-Id: req_Arxhy7yn9a1MsY
+Stripe-Account: acct_19jzyNJqXiFraDuL
+Stripe-Version: 2015-04-07
+
+{
+  "error": {
+    "type": "invalid_request_error",
+    "message": "No such customer: cus_ArtrMQYPgb0QaUasd",
+    "param": "customer"
+  }
+}

--- a/tests/Mock/CreateTokenSuccess.txt
+++ b/tests/Mock/CreateTokenSuccess.txt
@@ -1,0 +1,50 @@
+HTTP/1.1 200 OK
+Server: nginx
+Date: Mon, 19 Jun 2017 00:28:43 GMT
+Content-Type: application/json
+Content-Length: 798
+Connection: keep-alive
+Access-Control-Allow-Credentials: true
+Access-Control-Allow-Methods: GET, POST, HEAD, OPTIONS, DELETE
+Access-Control-Allow-Origin: *
+Access-Control-Max-Age: 300
+Cache-Control: no-cache, no-store
+Request-Id: req_ArxgXN0W9YsXss
+Stripe-Account: acct_14901h0a0fh01293
+Stripe-Version: 2015-04-07
+Strict-Transport-Security: max-age=31556926; includeSubDomains
+
+{
+  "id": "tok_1AWDl1JqXiFraDuL2xOKEXKy",
+  "object": "token",
+  "card": {
+    "id": "card_1AWDl1JqXiFraDuL8KJpKlxe",
+    "object": "card",
+    "address_city": null,
+    "address_country": null,
+    "address_line1": null,
+    "address_line1_check": null,
+    "address_line2": null,
+    "address_state": null,
+    "address_zip": null,
+    "address_zip_check": null,
+    "brand": "Visa",
+    "country": "US",
+    "currency": "usd",
+    "cvc_check": null,
+    "dynamic_last4": null,
+    "exp_month": 8,
+    "exp_year": 2019,
+    "fingerprint": "OfIzYIod5lokCObt",
+    "funding": "credit",
+    "last4": "4242",
+    "metadata": {},
+    "name": null,
+    "tokenization_method": null
+  },
+  "client_ip": "179.24.124.12",
+  "created": 1497832123,
+  "livemode": false,
+  "type": "card",
+  "used": false
+}


### PR DESCRIPTION
I've been using Stripe for a while and the only thing I miss is the ability to create tokens from customer references. This is needed in the Connect API when you need to share customers between the platform and the connected accounts. This PR will add support for this last piece of the Connect API.