### PR TITLE
Restore extra headers to sendData

### DIFF
--- a/src/Message/AbstractRequest.php
+++ b/src/Message/AbstractRequest.php
@@ -192,7 +192,11 @@ abstract class AbstractRequest extends \Omnipay\Common\Message\AbstractRequest
      */
     public function sendData($data)
     {
-        $headers = array('Authorization' => 'Basic ' . base64_encode($this->getApiKey() . ':'));
+        $headers = array_merge(
+            $this->getHeaders(),
+            array('Authorization' => 'Basic ' . base64_encode($this->getApiKey() . ':'))
+        );
+
         $body = $data ? http_build_query($data, '', '&') : null;
         $httpResponse = $this->httpClient->request($this->getHttpMethod(), $this->getEndpoint(), $headers, $body);
 


### PR DESCRIPTION
When upgrading the gateway to Omnipay v3 it seems the merging of the extra headers in AbstractRequest::sendData was removed: 

https://github.com/thephpleague/omnipay-stripe/commit/65abb09235f8cff2c1db684b07ebad758344c78d#diff-f1a888a4f0baadb508b5a2bd87ed09c6L226

This pull request puts that back so that the `Stripe-Account` & `Idempotency-Key` headers are sent again when required.