### PR TITLE
Add support for setting API version header

### DIFF
--- a/src/Gateway.php
+++ b/src/Gateway.php
@@ -108,6 +108,7 @@ class Gateway extends AbstractGateway
     {
         return array(
             'apiKey' => '',
+            'version' => null,
         );
     }
 
@@ -149,6 +150,40 @@ class Gateway extends AbstractGateway
     public function setApiKey($value)
     {
         return $this->setParameter('apiKey', $value);
+    }
+
+    /**
+     * Get the API version.
+     *
+     * @return string|null
+     */
+    public function getVersion()
+    {
+        return $this->getParameter('version');
+    }
+
+    /**
+     * Set the API version.
+     *
+     * Your API version controls the API and webhook behavior you see (e.g.,
+     * what properties you see in responses, what parameters you’re permitted to
+     * send in requests, etc.). Stripe automatically sets your API version when
+     * you make your first request, and requests after that will automatically
+     * use the same API version unless you upgrade it in your Stripe dashboard.
+     *
+     * You can also provide a specific API version to use, which is suggested if
+     * the Stripe account's API version is not under your control.
+     *
+     * @see https://stripe.com/docs/upgrades
+     *
+     * @param string|null $value Stripe API version, or null to use the version
+     *                           set on the account.
+     *
+     * @return Gateway provides a fluent interface.
+     */
+    public function setVersion($value)
+    {
+        return $this->setParameter('version', $value);
     }
 
     /**

--- a/src/Message/AbstractRequest.php
+++ b/src/Message/AbstractRequest.php
@@ -112,6 +112,28 @@ abstract class AbstractRequest extends \Omnipay\Common\Message\AbstractRequest
     }
 
     /**
+     * Get the version.
+     *
+     * @return string
+     */
+    public function getVersion()
+    {
+        return $this->getParameter('version');
+    }
+
+    /**
+     * Set the version.
+     *
+     * @param string $value
+     *
+     * @return AbstractRequest provides a fluent interface.
+     */
+    public function setVersion($value)
+    {
+        return $this->setParameter('version', $value);
+    }
+
+    /**
      * Connect only
      *
      * @return mixed
@@ -171,6 +193,10 @@ abstract class AbstractRequest extends \Omnipay\Common\Message\AbstractRequest
     public function getHeaders()
     {
         $headers = array();
+
+        if ($this->getVersion()) {
+            $headers['Stripe-Version'] = $this->getVersion();
+        }
 
         if ($this->getConnectedStripeAccountHeader()) {
             $headers['Stripe-Account'] = $this->getConnectedStripeAccountHeader();

--- a/tests/Message/AbstractRequestTest.php
+++ b/tests/Message/AbstractRequestTest.php
@@ -21,6 +21,12 @@ class AbstractRequestTest extends TestCase
 
     public function testCardToken()
     {
+        $this->assertSame($this->request, $this->request->setCardToken('abc123'));
+        $this->assertSame('abc123', $this->request->getCardToken());
+    }
+
+    public function testToken()
+    {
         $this->assertSame($this->request, $this->request->setToken('abc123'));
         $this->assertSame('abc123', $this->request->getToken());
     }
@@ -78,7 +84,6 @@ class AbstractRequestTest extends TestCase
         $this->assertTrue($httpRequest->hasHeader('Idempotency-Key'));
     }
 
-
     public function testConnectedStripeAccount()
     {
         $this->request->setConnectedStripeAccountHeader('ACCOUNT_ID');
@@ -98,5 +103,16 @@ class AbstractRequestTest extends TestCase
         );
 
         $this->assertTrue($httpRequest->hasHeader('Stripe-Account'));
+    }
+
+    public function testVersion()
+    {
+        $this->assertSame($this->request, $this->request->setVersion('2001-01-01'));
+        $this->assertSame('2001-01-01', $this->request->getVersion());
+
+        $headers = $this->request->getHeaders();
+
+        $this->assertArrayHasKey('Stripe-Version', $headers);
+        $this->assertSame('2001-01-01', $headers['Stripe-Version']);
     }
 }


### PR DESCRIPTION
This is really useful to avoid things breaking with Stripe API updates if the Stripe account you're using is not one under your control.

Stripe's documentation on the version header is here: https://stripe.com/docs/upgrades

Example use cases would be:
* An online store SaaS where businesses enter their own Stripe API keys to use
* Writing software that will be installed by the user on their own web server to use with their Stripe account

We've been using this in production since February with no issues.