### PR TITLE
Fix issue #98

### DIFF
--- a/src/Message/CreatePlanRequest.php
+++ b/src/Message/CreatePlanRequest.php
@@ -149,7 +149,9 @@ class CreatePlanRequest extends AbstractRequest
             'amount' => $this->getAmountInteger(),
             'currency' => $this->getCurrency(),
             'interval' => $this->getInterval(),
-            'name' => $this->getName()
+            'product' => array(
+                'name' => $this->getName()
+            )
         );
 
         $intervalCount = $this->getIntervalCount();


### PR DESCRIPTION
'Plan::Create'  on stripe api has changed to 
`    
           'product' => array(
                'name' => $this->getName()
            )
`
instead of:
`           
     'name' => $this->getName()

`