### PR TITLE
Added support for shipping information

### DIFF
--- a/src/Message/CreateCustomerRequest.php
+++ b/src/Message/CreateCustomerRequest.php
@@ -104,6 +104,27 @@ class CreateCustomerRequest extends AbstractRequest
         return $this->setParameter('email', $value);
     }
 
+    /**
+     * Get the customer's shipping address.
+     *
+     * @return array
+     */
+    public function getShipping()
+    {
+        return $this->getParameter('shipping');
+    }
+
+    /**
+     * Sets the customer's shipping address.
+     *
+     * @param array $value
+     * @return CreateCustomerRequest provides a fluent interface.
+     */
+    public function setShipping($value)
+    {
+        return $this->setParameter('shipping', $value);
+    }
+
     public function getSource()
     {
         return $this->getParameter('source');
@@ -138,6 +159,10 @@ class CreateCustomerRequest extends AbstractRequest
 
         if ($this->getSource()) {
             $data['source'] = $this->getSource();
+        }
+
+        if ($this->getShipping()) {
+            $data['shipping'] = $this->getShipping();
         }
 
         return $data;

--- a/src/Message/UpdateCustomerRequest.php
+++ b/src/Message/UpdateCustomerRequest.php
@@ -50,11 +50,32 @@ class UpdateCustomerRequest extends AbstractRequest
      * Sets the customer's email address.
      *
      * @param string $value
-     * @return CreateCustomerRequest provides a fluent interface.
+     * @return UpdateCustomerRequest provides a fluent interface.
      */
     public function setEmail($value)
     {
         return $this->setParameter('email', $value);
+    }
+
+    /**
+     * Get the customer's shipping address.
+     *
+     * @return array
+     */
+    public function getShipping()
+    {
+        return $this->getParameter('shipping');
+    }
+
+    /**
+     * Sets the customer's shipping address.
+     *
+     * @param array $value
+     * @return UpdateCustomerRequest provides a fluent interface.
+     */
+    public function setShipping($value)
+    {
+        return $this->setParameter('shipping', $value);
     }
 
     /**
@@ -71,7 +92,7 @@ class UpdateCustomerRequest extends AbstractRequest
      * Sets the customer's source.
      *
      * @param string $value
-     * @return CreateCustomerRequest provides a fluent interface.
+     * @return UpdateCustomerRequest provides a fluent interface.
      */
     public function setSource($value)
     {
@@ -100,6 +121,10 @@ class UpdateCustomerRequest extends AbstractRequest
 
         if ($this->getSource()) {
             $data['source'] = $this->getSource();
+        }
+
+        if ($this->getShipping()) {
+            $data['shipping'] = $this->getShipping();
         }
 
         return $data;

--- a/tests/Message/CreateCustomerRequestTest.php
+++ b/tests/Message/CreateCustomerRequestTest.php
@@ -18,9 +18,12 @@ class CreateCustomerRequestTest extends TestCase
 
     public function testData()
     {
+        $shipping = array('name' => 'John Doe', ['address' => ['line1' => 'Some street']]);
+
         $this->request->setEmail('customer@business.dom');
         $this->request->setDescription('New customer');
         $this->request->setMetadata(array('field' => 'value'));
+        $this->request->setShipping($shipping);
 
         $data = $this->request->getData();
 
@@ -28,6 +31,7 @@ class CreateCustomerRequestTest extends TestCase
         $this->assertSame('New customer', $data['description']);
         $this->assertArrayHasKey('field', $data['metadata']);
         $this->assertSame('value', $data['metadata']['field']);
+        $this->assertSame($shipping, $data['shipping']);
     }
 
     public function testDataWithToken()

--- a/tests/Message/UpdateCustomerRequestTest.php
+++ b/tests/Message/UpdateCustomerRequestTest.php
@@ -19,9 +19,12 @@ class UpdateCustomerRequestTest extends TestCase
 
     public function testData()
     {
+        $shipping = array('name' => 'John Doe', ['address' => ['line1' => 'Some street']]);
+
         $this->request->setEmail('customer@business.dom');
         $this->request->setDescription('New customer');
         $this->request->setMetadata(array('field' => 'value'));
+        $this->request->setshipping($shipping);
 
         $data = $this->request->getData();
 
@@ -29,6 +32,7 @@ class UpdateCustomerRequestTest extends TestCase
         $this->assertSame('New customer', $data['description']);
         $this->assertArrayHasKey('field', $data['metadata']);
         $this->assertSame('value', $data['metadata']['field']);
+        $this->assertSame($shipping, $data['shipping']);
     }
 
     public function testDataWithToken()


### PR DESCRIPTION
This PR allows to send [`shipping` information](https://stripe.com/docs/api/customers/create#create_customer-shipping) to Stripe.

This fixes https://github.com/thephpleague/omnipay-stripe/issues/115