### PR TITLE
getRequestId() method is not able to capture header (issue #123)

### DIFF
--- a/src/Message/Response.php
+++ b/src/Message/Response.php
@@ -386,8 +386,8 @@ class Response extends AbstractResponse
      */
     public function getRequestId()
     {
-        if (isset($this->headers['Request-Id'])) {
-            return $this->headers['Request-Id'][0];
+        if (isset($this->headers[strtolower('Request-Id')])) {
+            return $this->headers[strtolower('Request-Id')][0];
         }
 
         return null;

--- a/src/Message/Response.php
+++ b/src/Message/Response.php
@@ -386,8 +386,12 @@ class Response extends AbstractResponse
      */
     public function getRequestId()
     {
-        if (isset($this->headers[strtolower('Request-Id')])) {
-            return $this->headers[strtolower('Request-Id')][0];
+        if (isset($this->headers['Request-Id'])) {
+            return $this->headers['Request-Id'][0];
+        } else {
+            if (isset($this->headers[strtolower('Request-Id')])) {
+                return $this->headers[strtolower('Request-Id')][0];
+            }
         }
 
         return null;


### PR DESCRIPTION
issue #123

```
public function getRequestId() {
        if (isset($this->headers['Request-Id'])) {
            return $this->headers['Request-Id'][0];
        }
        return null;
}
```
- given method is not able to capture header by key 'Request-Id' (reproduction is questionable)
- yet, using lowercased analogue 'request-id' returns expected...
- propose:
```
public function getRequestId() {
        if (isset($this->headers[strtolower('Request-Id')])) {
            return $this->headers[strtolower('Request-Id')][0];
        }
        return null;
}
```