### PR TITLE
Allow skipping billing details if creating payment method with token.

### DIFF
--- a/src/Message/PaymentIntents/CreatePaymentMethodRequest.php
+++ b/src/Message/PaymentIntents/CreatePaymentMethodRequest.php
@@ -69,9 +69,11 @@ class CreatePaymentMethodRequest extends AbstractRequest
             $this->validate('card');
         }
 
-        if ($billingDetails = $this->getBillingDetails()) {
+        if ($this->getCard() && $billingDetails = $this->getBillingDetails()) {
             $data['billing_details'] = $billingDetails;
         }
+
+        $data['type'] = 'card';
 
         return $data;
     }

--- a/tests/Message/PaymentIntents/CreatePaymentMethodRequestTest.php
+++ b/tests/Message/PaymentIntents/CreatePaymentMethodRequestTest.php
@@ -65,6 +65,14 @@ class CreatePaymentMethodRequestTest extends TestCase
         $this->assertSame('xyz', $data['source']);
     }
 
+    public function testNoBillingDetails()
+    {
+        $this->request->setCard(null);
+        $this->request->setToken('xyz');
+
+        $this->request->getData();
+    }
+
     public function testDataWithCard()
     {
         $card = $this->getValidCard();


### PR DESCRIPTION
Also, fix a bug where creating a payment method was not possible at all.