### PR TITLE
set stripe version via http header

### DIFF
--- a/src/Message/AbstractRequest.php
+++ b/src/Message/AbstractRequest.php
@@ -146,6 +146,25 @@ abstract class AbstractRequest extends \Omnipay\Common\Message\AbstractRequest
     }
 
     /**
+     *
+     * @return string
+     */
+    public function getStripeVersion()
+    {
+        return $this->getParameter('stripeVersion');
+    }
+
+    /**
+     * @param string $value
+     *
+     * @return AbstractRequest
+     */
+    public function setStripeVersion($value)
+    {
+        return $this->setParameter('stripeVersion', $value);
+    }
+
+    /**
      * @param string $value
      *
      * @return AbstractRequest
@@ -182,6 +201,10 @@ abstract class AbstractRequest extends \Omnipay\Common\Message\AbstractRequest
 
         if ($this->getIdempotencyKeyHeader()) {
             $headers['Idempotency-Key'] = $this->getIdempotencyKeyHeader();
+        }
+
+        if ($this->getStripeVersion()) {
+            $headers['Stripe-Version'] = $this->getStripeVersion();
         }
 
         return $headers;

--- a/src/Message/PaymentIntents/CreatePaymentMethodRequest.php
+++ b/src/Message/PaymentIntents/CreatePaymentMethodRequest.php
@@ -69,9 +69,11 @@ class CreatePaymentMethodRequest extends AbstractRequest
             $this->validate('card');
         }
 
-        if ($billingDetails = $this->getBillingDetails()) {
+        if ($this->getCard() && $billingDetails = $this->getBillingDetails()) {
             $data['billing_details'] = $billingDetails;
         }
+
+        $data['type'] = 'card';
 
         return $data;
     }

--- a/tests/Message/AbstractRequestTest.php
+++ b/tests/Message/AbstractRequestTest.php
@@ -78,6 +78,26 @@ class AbstractRequestTest extends TestCase
         $this->assertTrue($httpRequest->hasHeader('Idempotency-Key'));
     }
 
+    public function testStripeVersion()
+    {
+        $this->request->setStripeVersion('2019-05-16');
+
+        $this->assertSame('2019-05-16', $this->request->getStripeVersion());
+
+        $headers = $this->request->getHeaders();
+
+        $this->assertArrayHasKey('Stripe-Version', $headers);
+        $this->assertSame('2019-05-16', $headers['Stripe-Version']);
+
+        $httpRequest = new Request(
+            'GET',
+            '/',
+            $headers
+        );
+
+        $this->assertTrue($httpRequest->hasHeader('Stripe-Version'));
+    }
+
 
     public function testConnectedStripeAccount()
     {

--- a/tests/Message/PaymentIntents/CreatePaymentMethodRequestTest.php
+++ b/tests/Message/PaymentIntents/CreatePaymentMethodRequestTest.php
@@ -65,6 +65,14 @@ class CreatePaymentMethodRequestTest extends TestCase
         $this->assertSame('xyz', $data['source']);
     }
 
+    public function testNoBillingDetails()
+    {
+        $this->request->setCard(null);
+        $this->request->setToken('xyz');
+        $this->request->getData();
+    }
+
+
     public function testDataWithCard()
     {
         $card = $this->getValidCard();


### PR DESCRIPTION
With this change it's now possible to set the Stripe-Version through the http header.
We intend to use the new Payment Intent Gateway but want to keep the set version in the dashboard for all other use cases where we use the stripe API to not break anything.