### PR TITLE
Extend payment intent support

### DIFF
--- a/src/Message/CreateCustomerRequest.php
+++ b/src/Message/CreateCustomerRequest.php
@@ -104,6 +104,22 @@ class CreateCustomerRequest extends AbstractRequest
         return $this->setParameter('email', $value);
     }
 
+    public function getName()
+    {
+        return $this->getParameter('name');
+    }
+
+    /**
+     * Sets the customer's name.
+     *
+     * @param string $value
+     * @return CreateCustomerRequest provides a fluent interface.
+     */
+    public function setName($value)
+    {
+        return $this->setParameter('name', $value);
+    }
+
     public function getSource()
     {
         return $this->getParameter('source');
@@ -138,6 +154,14 @@ class CreateCustomerRequest extends AbstractRequest
 
         if ($this->getSource()) {
             $data['source'] = $this->getSource();
+        }
+
+        if ($this->getName()) {
+            $data['name'] = $this->getName();
+        }
+
+        if ($this->getPaymentMethod()) {
+            $data['payment_method'] = $this->getPaymentMethod();
         }
 
         return $data;

--- a/src/Message/PaymentIntents/CancelPaymentIntentRequest.php
+++ b/src/Message/PaymentIntents/CancelPaymentIntentRequest.php
@@ -1,0 +1,50 @@
+<?php
+
+/**
+ * Stripe Payment Intents Cancel Request.
+ */
+namespace Omnipay\Stripe\Message\PaymentIntents;
+
+/**
+ * Stripe Cancel Payment Intent Request.
+ *
+ *  $paymentIntent = $gateway->cancelPaymentIntent(array(
+ *      'paymentIntentReference' => $paymentIntentReference,
+ *  ));
+ *
+ *  $response = $paymentIntent->send();
+ *
+ *  if ($response->isCancelled()) {
+ *    // All done
+ *  }
+ *
+ * @link https://stripe.com/docs/api/payment_intents/cancel
+ */
+class CancelPaymentIntentRequest extends AbstractRequest
+{
+    /**
+     * @inheritdoc
+     */
+    public function getData()
+    {
+        $this->validate('paymentIntentReference');
+
+        return [];
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function getEndpoint()
+    {
+        return $this->endpoint.'/payment_intents/' . $this->getPaymentIntentReference() . '/cancel';
+    }
+
+    /**
+     * @inheritdoc
+     */
+    protected function createResponse($data, $headers = [])
+    {
+        return $this->response = new Response($this, $data, $headers);
+    }
+}

--- a/src/Message/PaymentIntents/CancelPaymentIntentRequest.php
+++ b/src/Message/PaymentIntents/CancelPaymentIntentRequest.php
@@ -8,15 +8,17 @@ namespace Omnipay\Stripe\Message\PaymentIntents;
 /**
  * Stripe Cancel Payment Intent Request.
  *
- *  $paymentIntent = $gateway->cancelPaymentIntent(array(
- *      'paymentIntentReference' => $paymentIntentReference,
- *  ));
+ * <code>
+ *   $paymentIntent = $gateway->cancelPaymentIntent(array(
+ *       'paymentIntentReference' => $paymentIntentReference,
+ *   ));
  *
- *  $response = $paymentIntent->send();
+ *   $response = $paymentIntent->send();
  *
- *  if ($response->isCancelled()) {
- *    // All done
- *  }
+ *   if ($response->isCancelled()) {
+ *     // All done
+ *   }
+ * </code>
  *
  * @link https://stripe.com/docs/api/payment_intents/cancel
  */

--- a/src/Message/PaymentIntents/FetchPaymentMethodRequest.php
+++ b/src/Message/PaymentIntents/FetchPaymentMethodRequest.php
@@ -1,0 +1,60 @@
+<?php
+
+/**
+ * Stripe Fetch Payment Method Request.
+ */
+namespace Omnipay\Stripe\Message\PaymentIntents;
+
+/**
+ * Stripe Fetch Payment Method Request.
+ *
+ * <code>
+ *   $paymentMethod = $gateway->fetchPaymentMethod(array(
+ *       'paymentMethodId' => $paymentMethodId,
+ *   ));
+ *
+ *   $response = $paymentMethod->send();
+ *
+ *   if ($response->isSuccessful()) {
+ *     // All done
+ *   }
+ * </code>
+ *
+ * @link https://stripe.com/docs/api/payment_methods/retrieve
+ */
+class FetchPaymentMethodRequest extends AbstractRequest
+{
+    /**
+     * @inheritdoc
+     */
+    public function getData()
+    {
+        $this->validate('paymentMethod');
+
+        return [];
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function getHttpMethod()
+    {
+        return 'GET';
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function getEndpoint()
+    {
+        return $this->endpoint . '/payment_methods/' . $this->getPaymentMethod();
+    }
+
+    /**
+     * @inheritdoc
+     */
+    protected function createResponse($data, $headers = [])
+    {
+        return $this->response = new Response($this, $data, $headers);
+    }
+}

--- a/src/Message/PaymentIntents/Response.php
+++ b/src/Message/PaymentIntents/Response.php
@@ -123,6 +123,18 @@ class Response extends BaseResponse
     /**
      * @inheritdoc
      */
+    public function isCancelled()
+    {
+        if (isset($this->data['object']) && 'payment_intent' === $this->data['object']) {
+            return $this->getStatus() === 'canceled';
+        }
+
+        return parent::isCancelled();
+    }
+
+    /**
+     * @inheritdoc
+     */
     public function isRedirect()
     {
         if ($this->getStatus() === 'requires_action') {

--- a/src/PaymentIntentsGateway.php
+++ b/src/PaymentIntentsGateway.php
@@ -120,6 +120,14 @@ class PaymentIntentsGateway extends AbstractGateway
     //
 
     /**
+     * @return \Omnipay\Stripe\Message\PaymentIntents\FetchPaymentMethodRequest
+     */
+    public function fetchCard(array $parameters = array())
+    {
+        return $this->createRequest('\Omnipay\Stripe\Message\PaymentIntents\FetchPaymentMethodRequest', $parameters);
+    }
+
+    /**
      * @inheritdoc
      *
      * @return \Omnipay\Stripe\Message\PaymentIntents\CreatePaymentMethodRequest

--- a/src/PaymentIntentsGateway.php
+++ b/src/PaymentIntentsGateway.php
@@ -71,6 +71,17 @@ class PaymentIntentsGateway extends AbstractGateway
     }
 
     /**
+     * Cancel a Payment Intent.
+     *
+     * @param array $parameters
+     * @return \Omnipay\Stripe\Message\PaymentIntents\CancelPaymentIntentRequest
+     */
+    public function cancel(array $parameters = array())
+    {
+        return $this->createRequest('\Omnipay\Stripe\Message\PaymentIntents\CancelPaymentIntentRequest', $parameters);
+    }
+
+    /**
      * @inheritdoc
      *
      * @return \Omnipay\Stripe\Message\PaymentIntents\PurchaseRequest

--- a/tests/Message/CreateCustomerRequestTest.php
+++ b/tests/Message/CreateCustomerRequestTest.php
@@ -6,6 +6,9 @@ use Omnipay\Tests\TestCase;
 
 class CreateCustomerRequestTest extends TestCase
 {
+    /** @var CreateCustomerRequest */
+    protected $request;
+
     public function setUp()
     {
         $this->request = new CreateCustomerRequest($this->getHttpClient(), $this->getHttpRequest());
@@ -20,7 +23,9 @@ class CreateCustomerRequestTest extends TestCase
     {
         $this->request->setEmail('customer@business.dom');
         $this->request->setDescription('New customer');
-        $this->request->setMetadata(array('field' => 'value'));
+        $this->request->setMetadata(['field' => 'value']);
+        $this->request->setPaymentMethod('payment_method_id');
+        $this->request->setName('Customer Name');
 
         $data = $this->request->getData();
 
@@ -28,6 +33,8 @@ class CreateCustomerRequestTest extends TestCase
         $this->assertSame('New customer', $data['description']);
         $this->assertArrayHasKey('field', $data['metadata']);
         $this->assertSame('value', $data['metadata']['field']);
+        $this->assertSame('payment_method_id', $data['payment_method']);
+        $this->assertSame('Customer Name', $data['name']);
     }
 
     public function testDataWithToken()

--- a/tests/Message/PaymentIntents/CancelPaymentIntentRequestTest.php
+++ b/tests/Message/PaymentIntents/CancelPaymentIntentRequestTest.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace Omnipay\Stripe\Message\PaymentIntents;
+
+use Omnipay\Tests\TestCase;
+
+class CancelPaymentIntentRequestTest extends TestCase
+{
+    public function setUp()
+    {
+        $this->request = new CancelPaymentIntentRequest($this->getHttpClient(), $this->getHttpRequest());
+        $this->request->setPaymentIntentReference('pi_valid_intent');
+    }
+
+    public function testEndpoint()
+    {
+        $this->assertSame('https://api.stripe.com/v1/payment_intents/pi_valid_intent/cancel', $this->request->getEndpoint());
+    }
+
+    /**
+     * @expectedException \Omnipay\Common\Exception\InvalidRequestException
+     * @expectedExceptionMessage The paymentIntentReference parameter is required
+     */
+    public function testPaymentIntent()
+    {
+        $this->request->setPaymentIntentReference(null);
+        $this->request->getData();
+    }
+
+    public function testData()
+    {
+        $this->assertEmpty($this->request->getData());
+    }
+
+    public function testCancelSuccess()
+    {
+        $this->setMockHttpResponse('CancelPaymentIntentSuccess.txt');
+        $response = $this->request->send();
+
+        $this->assertTrue($response->isCancelled());
+        $this->assertFalse($response->isSuccessful());
+        $this->assertFalse($response->isRedirect());
+        $this->assertSame('ch_1F4OqH2okp6n5dKoWlN61H9w', $response->getTransactionReference());
+        $this->assertSame('pm_1F4Oq02okp6n5dKoKfHmMyJN', $response->getCardReference());
+        $this->assertNull($response->getMessage());
+    }
+
+    public function testCancelFailure()
+    {
+        $this->setMockHttpResponse('CancelPaymentIntentFailure.txt');
+        $response = $this->request->send();
+
+        $this->assertFalse($response->isCancelled());
+        $this->assertFalse($response->isSuccessful());
+        $this->assertFalse($response->isRedirect());
+        $this->assertNull($response->getTransactionReference());
+        $this->assertSame('You cannot cancel this PaymentIntent because it has a status of canceled. Only a PaymentIntent with one of the following statuses may be canceled: requires_payment_method, requires_capture, requires_confirmation, requires_action.', $response->getMessage());
+    }
+}

--- a/tests/Message/PaymentIntents/FetchPaymentMethodRequestTest.php
+++ b/tests/Message/PaymentIntents/FetchPaymentMethodRequestTest.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace Omnipay\Stripe\Message\PaymentIntents;
+
+use Omnipay\Tests\TestCase;
+
+class FetchPaymentMethodRequestTest extends TestCase
+{
+    public function setUp()
+    {
+        $this->request = new FetchPaymentMethodRequest($this->getHttpClient(), $this->getHttpRequest());
+        $this->request->setPaymentMethod('pm_valid_method');
+    }
+
+    public function testEndpoint()
+    {
+        $this->assertSame('https://api.stripe.com/v1/payment_methods/pm_valid_method', $this->request->getEndpoint());
+    }
+
+    public function testHttpMethod()
+    {
+        $this->assertSame('GET', $this->request->getHttpMethod());
+    }
+
+    public function testSendSuccess()
+    {
+        $this->setMockHttpResponse('FetchPaymentMethodSuccess.txt');
+        $response = $this->request->send();
+        $this->assertTrue($response->isSuccessful());
+        $this->assertSame('pm_1F55vt2okp6n5dXo2WxJfirJ', $response->getCardReference());
+        $this->assertSame('cus_FaCqpKDSJvFSsC', $response->getCustomerReference());
+    }
+
+    public function testSendFailure()
+    {
+        $this->setMockHttpResponse('FetchPaymentMethodFailure.txt');
+        $response = $this->request->send();
+        $this->assertFalse($response->isSuccessful());
+        $this->assertNull($response->getCardReference());
+        $this->assertNull($response->getCustomerReference());
+        $this->assertSame('No such payment_method: pm_1F52R22okp6n5dKoGSAKgKUX', $response->getMessage());
+    }
+}

--- a/tests/Message/PaymentIntents/Mock/CancelPaymentIntentFailure.txt
+++ b/tests/Message/PaymentIntents/Mock/CancelPaymentIntentFailure.txt
@@ -1,4 +1,4 @@
-HTTP/2 400
+HTTP/1.1 400 Bad Request
 server: nginx
 date: Wed, 07 Aug 2019 01:29:44 GMT
 content-type: application/json

--- a/tests/Message/PaymentIntents/Mock/CancelPaymentIntentFailure.txt
+++ b/tests/Message/PaymentIntents/Mock/CancelPaymentIntentFailure.txt
@@ -1,0 +1,80 @@
+HTTP/2 400
+server: nginx
+date: Wed, 07 Aug 2019 01:29:44 GMT
+content-type: application/json
+content-length: 2005
+access-control-allow-credentials: true
+access-control-allow-methods: GET, POST, HEAD, OPTIONS, DELETE
+access-control-allow-origin: *
+access-control-expose-headers: Request-Id, Stripe-Manage-Version, X-Stripe-External-Auth-Required, X-Stripe-Privileged-Session-Required
+access-control-max-age: 300
+cache-control: no-cache, no-store
+request-id: req_W9rdDlUahgd6iC
+stripe-version: 2018-05-21
+strict-transport-security: max-age=31556926; includeSubDomains; preload
+
+{
+  "error": {
+    "code": "payment_intent_unexpected_state",
+    "doc_url": "https://stripe.com/docs/error-codes/payment-intent-unexpected-state",
+    "message": "You cannot cancel this PaymentIntent because it has a status of canceled. Only a PaymentIntent with one of the following statuses may be canceled: requires_payment_method, requires_capture, requires_confirmation, requires_action.",
+    "payment_intent": {
+      "id": "pi_1Evf5q2okp6n5dKoviPU2IkK",
+      "object": "payment_intent",
+      "allowed_source_types": [
+        "card"
+      ],
+      "amount": 1099,
+      "amount_capturable": 0,
+      "amount_received": 0,
+      "application": null,
+      "application_fee_amount": null,
+      "canceled_at": 1565141374,
+      "cancellation_reason": null,
+      "capture_method": "automatic",
+      "charges": {
+        "object": "list",
+        "data": [
+
+        ],
+        "has_more": false,
+        "total_count": 0,
+        "url": "/v1/charges?payment_intent=pi_1Evf5q2okp6n5dKoviPU2IkK"
+      },
+      "client_secret": "pi_1Evf5q2okp6n5dKoviPU2IkK_secret_uXzcxJ2um6t790XAokzr2HsTN",
+      "confirmation_method": "automatic",
+      "created": 1563000746,
+      "currency": "aud",
+      "customer": null,
+      "description": null,
+      "invoice": null,
+      "last_payment_error": null,
+      "livemode": false,
+      "metadata": {
+      },
+      "next_action": null,
+      "next_source_action": null,
+      "on_behalf_of": null,
+      "payment_method": null,
+      "payment_method_options": {
+        "card": {
+          "request_three_d_secure": "automatic"
+        }
+      },
+      "payment_method_types": [
+        "card"
+      ],
+      "receipt_email": null,
+      "review": null,
+      "setup_future_usage": "off_session",
+      "shipping": null,
+      "source": null,
+      "statement_descriptor": null,
+      "statement_descriptor_suffix": null,
+      "status": "canceled",
+      "transfer_data": null,
+      "transfer_group": null
+    },
+    "type": "invalid_request_error"
+  }
+}

--- a/tests/Message/PaymentIntents/Mock/CancelPaymentIntentSuccess.txt
+++ b/tests/Message/PaymentIntents/Mock/CancelPaymentIntentSuccess.txt
@@ -1,4 +1,4 @@
-HTTP/2 200
+HTTP/1.1 200 OK
 server: nginx
 date: Wed, 07 Aug 2019 04:08:43 GMT
 content-type: application/json

--- a/tests/Message/PaymentIntents/Mock/CancelPaymentIntentSuccess.txt
+++ b/tests/Message/PaymentIntents/Mock/CancelPaymentIntentSuccess.txt
@@ -1,0 +1,182 @@
+HTTP/2 200
+server: nginx
+date: Wed, 07 Aug 2019 04:08:43 GMT
+content-type: application/json
+content-length: 4790
+access-control-allow-credentials: true
+access-control-allow-methods: GET, POST, HEAD, OPTIONS, DELETE
+access-control-allow-origin: *
+access-control-expose-headers: Request-Id, Stripe-Manage-Version, X-Stripe-External-Auth-Required, X-Stripe-Privileged-Session-Required
+access-control-max-age: 300
+cache-control: no-cache, no-store
+request-id: req_pDQDQOBBz7ipht
+stripe-version: 2018-05-21
+strict-transport-security: max-age=31556926; includeSubDomains; preload
+
+{
+  "id": "pi_1F4Oq22okp6n5dKoErGka6we",
+  "object": "payment_intent",
+  "allowed_source_types": [
+    "card"
+  ],
+  "amount": 52510,
+  "amount_capturable": 0,
+  "amount_received": 0,
+  "application": null,
+  "application_fee_amount": null,
+  "canceled_at": 1565150923,
+  "cancellation_reason": null,
+  "capture_method": "manual",
+  "charges": {
+    "object": "list",
+    "data": [
+      {
+        "id": "ch_1F4OqH2okp6n5dKoWlN61H9w",
+        "object": "charge",
+        "amount": 52510,
+        "amount_refunded": 52510,
+        "application": null,
+        "application_fee": null,
+        "application_fee_amount": null,
+        "balance_transaction": null,
+        "billing_details": {
+          "address": {
+            "city": "New York",
+            "country": "US",
+            "line1": "325 Broadway",
+            "line2": null,
+            "postal_code": "10007",
+            "state": "New York"
+          },
+          "email": null,
+          "name": "Jack Beanstalk",
+          "phone": null
+        },
+        "captured": false,
+        "created": 1565083229,
+        "currency": "usd",
+        "customer": "cus_FZXvpeIdgVYdmq",
+        "description": null,
+        "destination": null,
+        "dispute": null,
+        "failure_code": null,
+        "failure_message": null,
+        "fraud_details": {
+        },
+        "invoice": null,
+        "livemode": false,
+        "metadata": {
+        },
+        "on_behalf_of": null,
+        "order": null,
+        "outcome": {
+          "network_status": "approved_by_network",
+          "reason": null,
+          "risk_level": "normal",
+          "risk_score": 1,
+          "seller_message": "Payment complete.",
+          "type": "authorized"
+        },
+        "paid": true,
+        "payment_intent": "pi_1F4Oq22okp6n5dKoErGka6we",
+        "payment_method": "pm_1F4Oq02okp6n5dKoKfHmMyJN",
+        "payment_method_details": {
+          "card": {
+            "brand": "visa",
+            "checks": {
+              "address_line1_check": "pass",
+              "address_postal_code_check": "pass",
+              "cvc_check": "pass"
+            },
+            "country": null,
+            "exp_month": 2,
+            "exp_year": 2022,
+            "fingerprint": "TfHYiz2pR4RQdLsw",
+            "funding": "credit",
+            "last4": "3220",
+            "three_d_secure": {
+              "authenticated": true,
+              "succeeded": true,
+              "version": "2.1.0"
+            },
+            "wallet": null
+          },
+          "type": "card"
+        },
+        "receipt_email": null,
+        "receipt_number": null,
+        "receipt_url": "redacted",
+        "refunded": true,
+        "refunds": {
+          "object": "list",
+          "data": [
+            {
+              "id": "re_1F4gS62okp6n5dKoWNSLVaLS",
+              "object": "refund",
+              "amount": 52510,
+              "balance_transaction": null,
+              "charge": "ch_1F4OqH2okp6n5dKoWlN61H9w",
+              "created": 1565150922,
+              "currency": "usd",
+              "metadata": {
+              },
+              "reason": null,
+              "receipt_number": null,
+              "source_transfer_reversal": null,
+              "status": "succeeded",
+              "transfer_reversal": null
+            }
+          ],
+          "has_more": false,
+          "total_count": 1,
+          "url": "/v1/charges/ch_1F4OqH2okp7n5dKoWlN61H9w/refunds"
+        },
+        "review": null,
+        "shipping": null,
+        "source": null,
+        "source_transfer": null,
+        "statement_descriptor": null,
+        "statement_descriptor_suffix": null,
+        "status": "succeeded",
+        "transfer_data": null,
+        "transfer_group": null
+      }
+    ],
+    "has_more": false,
+    "total_count": 1,
+    "url": "/v1/charges?payment_intent=pi_1F4Oq22okp6n5dKoErGka6we"
+  },
+  "client_secret": "pi_1F4Oq22okp6n5dKoErGka68e_secret_rUBo6oC0Tvx1V12QBZMimJrCS",
+  "confirmation_method": "manual",
+  "created": 1565083214,
+  "currency": "usd",
+  "customer": "cus_FZXvpeIdgVYdmq",
+  "description": null,
+  "invoice": null,
+  "last_payment_error": null,
+  "livemode": false,
+  "metadata": {
+  },
+  "next_action": null,
+  "next_source_action": null,
+  "on_behalf_of": null,
+  "payment_method": "pm_1F4Oq02okp6n5dKoKfHmMyJN",
+  "payment_method_options": {
+    "card": {
+      "request_three_d_secure": "automatic"
+    }
+  },
+  "payment_method_types": [
+    "card"
+  ],
+  "receipt_email": null,
+  "review": null,
+  "setup_future_usage": "on_session",
+  "shipping": null,
+  "source": null,
+  "statement_descriptor": null,
+  "statement_descriptor_suffix": null,
+  "status": "canceled",
+  "transfer_data": null,
+  "transfer_group": null
+}

--- a/tests/Message/PaymentIntents/Mock/FetchPaymentMethodFailure.txt
+++ b/tests/Message/PaymentIntents/Mock/FetchPaymentMethodFailure.txt
@@ -1,0 +1,24 @@
+HTTP/1.1 404 Not Found
+server: nginx
+date: Fri, 09 Aug 2019 00:23:41 GMT
+content-type: application/json
+content-length: 261
+access-control-allow-credentials: true
+access-control-allow-methods: GET, POST, HEAD, OPTIONS, DELETE
+access-control-allow-origin: *
+access-control-expose-headers: Request-Id, Stripe-Manage-Version, X-Stripe-External-Auth-Required, X-Stripe-Privileged-Session-Required
+access-control-max-age: 300
+cache-control: no-cache, no-store
+request-id: req_CCSqQgjNH68hv0
+stripe-version: 2018-05-21
+strict-transport-security: max-age=31556926; includeSubDomains; preload
+
+{
+  "error": {
+    "code": "resource_missing",
+    "doc_url": "https://stripe.com/docs/error-codes/resource-missing",
+    "message": "No such payment_method: pm_1F52R22okp6n5dKoGSAKgKUX",
+    "param": "payment_method",
+    "type": "invalid_request_error"
+  }
+}

--- a/tests/Message/PaymentIntents/Mock/FetchPaymentMethodSuccess.txt
+++ b/tests/Message/PaymentIntents/Mock/FetchPaymentMethodSuccess.txt
@@ -1,0 +1,57 @@
+HTTP/1.1 200 OK
+server: nginx
+date: Fri, 09 Aug 2019 00:14:56 GMT
+content-type: application/json
+content-length: 906
+access-control-allow-credentials: true
+access-control-allow-methods: GET, POST, HEAD, OPTIONS, DELETE
+access-control-allow-origin: *
+access-control-expose-headers: Request-Id, Stripe-Manage-Version, X-Stripe-External-Auth-Required, X-Stripe-Privileged-Session-Required
+access-control-max-age: 300
+cache-control: no-cache, no-store
+request-id: req_uy4QJE6oEIHUFv
+stripe-version: 2018-05-21
+strict-transport-security: max-age=31556926; includeSubDomains; preload
+
+{
+  "id": "pm_1F55vt2okp6n5dXo2WxJfirJ",
+  "object": "payment_method",
+  "billing_details": {
+    "address": {
+      "city": "New Alessia",
+      "country": "AU",
+      "line1": "679 Berge Course",
+      "line2": null,
+      "postal_code": "50762-1465",
+      "state": "Alabama"
+    },
+    "email": "user@stripe.com",
+    "name": "Jack Beanstalk",
+    "phone": null
+  },
+  "card": {
+    "brand": "visa",
+    "checks": {
+      "address_line1_check": "pass",
+      "address_postal_code_check": "pass",
+      "cvc_check": "pass"
+    },
+    "country": "AU",
+    "exp_month": 2,
+    "exp_year": 2022,
+    "fingerprint": "bTL1Ce0N4U41rp8s",
+    "funding": "credit",
+    "generated_from": null,
+    "last4": "0006",
+    "three_d_secure_usage": {
+      "supported": true
+    },
+    "wallet": null
+  },
+  "created": 1565248870,
+  "customer": "cus_FaCqpKDSJvFSsC",
+  "livemode": false,
+  "metadata": {
+  },
+  "type": "card"
+}

--- a/tests/Message/PaymentIntents/ResponseTest.php
+++ b/tests/Message/PaymentIntents/ResponseTest.php
@@ -90,4 +90,19 @@ class ResponseTest extends TestCase
         $this->assertFalse($response->isRedirect());
         $this->assertNull($response->getRedirectUrl());
     }
+
+    public function testCancelled()
+    {
+        $httpResponse = $this->getMockHttpResponse('CancelPaymentIntentSuccess.txt');
+        $response = new Response($this->getMockRequest(), (string) $httpResponse->getBody());
+
+        $this->assertFalse($response->isSuccessful());
+        $this->assertTrue($response->isCancelled());
+
+        $httpResponse = $this->getMockHttpResponse('ConfirmIntentSuccess.txt');
+        $response = new Response($this->getMockRequest(), (string) $httpResponse->getBody());
+
+        $this->assertTrue($response->isSuccessful());
+        $this->assertFalse($response->isCancelled());
+    }
 }

--- a/tests/PaymentIntentsGatewayTest.php
+++ b/tests/PaymentIntentsGatewayTest.php
@@ -109,6 +109,15 @@ class PaymentIntentsGatewayTest extends GatewayTestCase
         $this->assertInstanceOf('Omnipay\Stripe\Message\FetchBalanceTransactionRequest', $request);
     }
 
+    public function testFetchCard()
+    {
+        $request = $this->gateway->fetchCard(array('paymentMethod' => 'pm_1EUon32Tb35ankTnF6nuoRVE'));
+
+        $this->assertInstanceOf('Omnipay\Stripe\Message\PaymentIntents\FetchPaymentMethodRequest', $request);
+        $this->assertSame('pm_1EUon32Tb35ankTnF6nuoRVE', $request->getPaymentMethod());
+        $this->assertSame('pm_1EUon32Tb35ankTnF6nuoRVE', $request->getCardReference());
+    }
+
     public function testCreateCard()
     {
         $request = $this->gateway->createCard(array('description' => 'foo', 'token' => 'tok_real_visa'));

--- a/tests/PaymentIntentsGatewayTest.php
+++ b/tests/PaymentIntentsGatewayTest.php
@@ -64,6 +64,14 @@ class PaymentIntentsGatewayTest extends GatewayTestCase
         $this->assertSame('pi_valid_intent', $request->getPaymentIntentReference());
     }
 
+    public function testCancelPaymentIntent()
+    {
+        $request = $this->gateway->cancel(array('paymentIntentReference' => 'pi_valid_intent'));
+
+        $this->assertInstanceOf('Omnipay\Stripe\Message\PaymentIntents\CancelPaymentIntentRequest', $request);
+        $this->assertSame('pi_valid_intent', $request->getPaymentIntentReference());
+    }
+
     public function testRefund()
     {
         $request = $this->gateway->refund(array('amount' => '10.00'));


### PR DESCRIPTION
Related to the recent Payment Intents PR #128

- Add support for canceling payment intents
- Add support for fetching payment methods