### PR TITLE
Allow configuring `Stripe-Version` at the gateway level

### DIFF
--- a/src/AbstractGateway.php
+++ b/src/AbstractGateway.php
@@ -107,6 +107,7 @@ abstract class AbstractGateway extends AbstractOmnipayGateway
     {
         return array(
             'apiKey' => '',
+            'stripeVersion' => null
         );
     }
 
@@ -148,6 +149,24 @@ abstract class AbstractGateway extends AbstractOmnipayGateway
     public function setApiKey($value)
     {
         return $this->setParameter('apiKey', $value);
+    }
+
+    /**
+     * @return string
+     */
+    public function getStripeVersion()
+    {
+        return $this->getParameter('stripeVersion');
+    }
+
+    /**
+     * @param string $value
+     *
+     * @return Gateway
+     */
+    public function setStripeVersion($value)
+    {
+        return $this->setParameter('stripeVersion', $value);
     }
 
     /**


### PR DESCRIPTION
This change allows setting the Stripe version header at the gateway level. We routinely parse out some of the additional data returned by Stripe in our application and require all requests to be tied to a specific version.

No additional tests are needed since `GatewayTestCase::testDefaultParametersHaveMatchingMethods` automatically tests all default parameter getters and setters.

This change expands on https://github.com/thephpleague/omnipay-stripe/pull/136 (which only allows setting the version at the request level).

This possibly fixes https://github.com/thephpleague/omnipay-stripe/issues/135.

This also supersedes / fixes https://github.com/thephpleague/omnipay-stripe/pull/110 which appears to be stale due to https://github.com/thephpleague/omnipay-stripe/pull/136.