### PR TITLE
Support for expanding Stripe objects in the response

### DIFF
--- a/tests/Message/AbstractRequestTest.php
+++ b/tests/Message/AbstractRequestTest.php
@@ -8,6 +8,9 @@ use Omnipay\Tests\TestCase;
 
 class AbstractRequestTest extends TestCase
 {
+    /** @var Mockery\Mock|AbstractRequest */
+    private $request;
+
     public function setUp()
     {
         $this->request = Mockery::mock('\Omnipay\Stripe\Message\AbstractRequest')->makePartial();
@@ -98,7 +101,6 @@ class AbstractRequestTest extends TestCase
         $this->assertTrue($httpRequest->hasHeader('Stripe-Version'));
     }
 
-
     public function testConnectedStripeAccount()
     {
         $this->request->setConnectedStripeAccountHeader('ACCOUNT_ID');
@@ -117,5 +119,15 @@ class AbstractRequestTest extends TestCase
         );
 
         $this->assertTrue($httpRequest->hasHeader('Stripe-Account'));
+    }
+
+    public function testExpandedEndpoint()
+    {
+        $this->request->shouldReceive('getEndpoint')->andReturn('https://api.stripe.com/v1');
+        $this->request->setExpand(['foo', 'bar']);
+
+        $actual = $this->request->getExpandedEndpoint();
+
+        $this->assertEquals('https://api.stripe.com/v1?expand[]=foo&expand[]=bar', $actual);
     }
 }


### PR DESCRIPTION
Our application sometimes has to fetch a related Stripe object after performing a charge (`balance_transaction` in our particular case). The extra round trip is unnecessary because the Stripe API supports "expanding" objects in the response (https://stripe.com/docs/api/expanding_objects).

This PR introduces support for the `expand` parameter and allows any request to Stripe to specify which of the response objects to "expand".