### PR TITLE
Added void option

### DIFF
--- a/src/PaymentIntentsGateway.php
+++ b/src/PaymentIntentsGateway.php
@@ -69,6 +69,17 @@ class PaymentIntentsGateway extends AbstractGateway
     {
         return $this->createRequest('\Omnipay\Stripe\Message\PaymentIntents\ConfirmPaymentIntentRequest', $parameters);
     }
+    
+    /**
+     * Void a Payment Intent.
+     *
+     * @param array $parameters
+     * @return \Omnipay\Stripe\Message\PaymentIntents\CancelPaymentIntentRequest
+     */
+    public function void(array $parameters = array())
+    {
+        return $this->createRequest('\Omnipay\Stripe\Message\PaymentIntents\CancelPaymentIntentRequest', $parameters);
+    }
 
     /**
      * Cancel a Payment Intent.


### PR DESCRIPTION
To keep consistency with old API I've added a `void` function which maps `cancel`.