### PR TITLE
Update AuthorizeRequest.php

### DIFF
--- a/src/Message/AuthorizeRequest.php
+++ b/src/Message/AuthorizeRequest.php
@@ -284,7 +284,7 @@ class AuthorizeRequest extends AbstractRequest
         }
 
         if ($this->getApplicationFee()) {
-            $data['application_fee'] = $this->getApplicationFeeInteger();
+            $data['application_fee_amount'] = $this->getApplicationFeeInteger();
         }
 
         if ($this->getTransferGroup()) {


### PR DESCRIPTION
According Stripe official documentation and also responses from the Stripe API, there was a mistake on the **application_fee** parameter. It should be **application_fee_amount**.

This is a real response from Stripe API, about this incorrect parameter:

```
{
  "error": {
    "code": "parameter_unknown",
    "doc_url": "https://stripe.com/docs/error-codes/parameter-unknown",
    "message": "Received unknown parameter: application_fee. Did you mean application_fee_amount?",
    "param": "application_fee",
    "type": "invalid_request_error"
  }
}
```

Please, approve this Pull Request to have this solved and working.

Thank you very much.