### PR TITLE
Setup Intent implementation & off_session payments for Payment Intent

### DIFF
--- a/src/Message/PaymentIntents/AuthorizeRequest.php
+++ b/src/Message/PaymentIntents/AuthorizeRequest.php
@@ -127,6 +127,26 @@ class AuthorizeRequest extends AbstractRequest
     }
 
     /**
+     * Set the confirm parameter.
+     *
+     * @param $value
+     */
+    public function setOffSession($value)
+    {
+        $this->setParameter('offSession', $value);
+    }
+
+    /**
+     * Get the confirm parameter.
+     *
+     * @return mixed
+     */
+    public function getOffSession()
+    {
+        return $this->getParameter('offSession');
+    }
+
+    /**
      * @return mixed
      */
     public function getDestination()
@@ -352,6 +372,8 @@ class AuthorizeRequest extends AbstractRequest
             $this->validate('returnUrl');
             $data['return_url'] = $this->getReturnUrl();
         }
+        $data['off_session'] = $this->getOffSession() ? 'true' : 'false';
+
 
         return $data;
     }

--- a/src/Message/SetupIntents/AbstractRequest.php
+++ b/src/Message/SetupIntents/AbstractRequest.php
@@ -35,5 +35,4 @@ abstract class AbstractRequest extends \Omnipay\Stripe\Message\AbstractRequest
     {
         return $this->getParameter('setupIntentReference');
     }
-
 }

--- a/src/Message/SetupIntents/AbstractRequest.php
+++ b/src/Message/SetupIntents/AbstractRequest.php
@@ -1,0 +1,39 @@
+<?php
+
+/**
+ * Stripe Abstract Request.
+ */
+
+namespace Omnipay\Stripe\Message\SetupIntents;
+
+/**
+ * Stripe Payment Intent Abstract Request.
+ *
+ * This is the parent class for all Stripe payment intent requests.
+ * It adds just a getter and setter.
+ *
+ * @see \Omnipay\Stripe\PaymentIntentsGateway
+ * @see \Omnipay\Stripe\Message\AbstractRequest
+ * @link https://stripe.com/docs/api/payment_intents
+ */
+abstract class AbstractRequest extends \Omnipay\Stripe\Message\AbstractRequest
+{
+    /**
+     * @param string $value
+     *
+     * @return AbstractRequest provides a fluent interface.
+     */
+    public function setSetupIntentReference($value)
+    {
+        return $this->setParameter('paymentIntentReference', $value);
+    }
+
+    /**
+     * @return mixed
+     */
+    public function getSetupIntentReference()
+    {
+        return $this->getParameter('paymentIntentReference');
+    }
+
+}

--- a/src/Message/SetupIntents/AbstractRequest.php
+++ b/src/Message/SetupIntents/AbstractRequest.php
@@ -25,7 +25,7 @@ abstract class AbstractRequest extends \Omnipay\Stripe\Message\AbstractRequest
      */
     public function setSetupIntentReference($value)
     {
-        return $this->setParameter('paymentIntentReference', $value);
+        return $this->setParameter('setupIntentReference', $value);
     }
 
     /**
@@ -33,7 +33,7 @@ abstract class AbstractRequest extends \Omnipay\Stripe\Message\AbstractRequest
      */
     public function getSetupIntentReference()
     {
-        return $this->getParameter('paymentIntentReference');
+        return $this->getParameter('setupIntentReference');
     }
 
 }

--- a/src/Message/SetupIntents/CreateSetupIntentRequest.php
+++ b/src/Message/SetupIntents/CreateSetupIntentRequest.php
@@ -3,6 +3,7 @@
 /**
  * Stripe Create Payment Method Request.
  */
+
 namespace Omnipay\Stripe\Message\SetupIntents;
 
 /**
@@ -31,14 +32,14 @@ class CreateSetupIntentRequest extends AbstractRequest
         if ($this->getCustomerReference()) {
             $data['customer'] = $this->getCustomerReference();
         }
-        if ($this->getDescription()){
+        if ($this->getDescription()) {
             $data['description'] = $this->getDescription();
         }
 
-        if ($this->getMetadata()){
+        if ($this->getMetadata()) {
             $this['metadata'] = $this->getMetadata();
         }
-        if ($this->getPaymentMethod()){
+        if ($this->getPaymentMethod()) {
             $this['payment_method'] = $this->getPaymentMethod();
         }
 
@@ -53,7 +54,7 @@ class CreateSetupIntentRequest extends AbstractRequest
      */
     public function getEndpoint()
     {
-        return $this->endpoint.'/setup_intents';
+        return $this->endpoint . '/setup_intents';
     }
 
     /**

--- a/src/Message/SetupIntents/CreateSetupIntentRequest.php
+++ b/src/Message/SetupIntents/CreateSetupIntentRequest.php
@@ -1,0 +1,66 @@
+<?php
+
+/**
+ * Stripe Create Payment Method Request.
+ */
+namespace Omnipay\Stripe\Message\SetupIntents;
+
+/**
+ * Stripe create setup intent
+ *
+ * ### Example
+ *
+ * <code>
+ *
+ * </code>
+ *
+ * @see \Omnipay\Stripe\Message\PaymentIntents\AttachPaymentMethodRequest
+ * @see \Omnipay\Stripe\Message\PaymentIntents\DetachPaymentMethodRequest
+ * @see \Omnipay\Stripe\Message\PaymentIntents\UpdatePaymentMethodRequest
+ * @link https://stripe.com/docs/api/setup_intents/create
+ */
+class CreateSetupIntentRequest extends AbstractRequest
+{
+    /**
+     * @inheritdoc
+     */
+    public function getData()
+    {
+        $data = [];
+
+        if ($this->getCustomerReference()) {
+            $data['customer'] = $this->getCustomerReference();
+        }
+        if ($this->getDescription()){
+            $data['description'] = $this->getDescription();
+        }
+
+        if ($this->getMetadata()){
+            $this['metadata'] = $this->getMetadata();
+        }
+        if ($this->getPaymentMethod()){
+            $this['payment_method'] = $this->getPaymentMethod();
+        }
+
+        $data['usage'] = 'off_session';
+        $data['payment_method_types'][] = 'card';
+
+        return $data;
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function getEndpoint()
+    {
+        return $this->endpoint.'/setup_intents';
+    }
+
+    /**
+     * @inheritdoc
+     */
+    protected function createResponse($data, $headers = [])
+    {
+        return $this->response = new Response($this, $data, $headers);
+    }
+}

--- a/src/Message/SetupIntents/Response.php
+++ b/src/Message/SetupIntents/Response.php
@@ -74,7 +74,7 @@ class Response extends BaseResponse implements ResponseInterface
     public function isSuccessful()
     {
         if (isset($this->data['object']) && 'setup_intent' === $this->data['object']) {
-            return in_array($this->getStatus(), ['succeeded', 'requires_capture']);
+            return in_array($this->getStatus(), ['succeeded', 'requires_payment_method']);
         }
 
         return parent::isSuccessful();
@@ -123,6 +123,20 @@ class Response extends BaseResponse implements ResponseInterface
     {
         if (isset($this->data['object']) && 'setup_intent' === $this->data['object']) {
             return $this->data['id'];
+        }
+
+        return null;
+    }
+
+    /**
+     * Get the payment intent reference.
+     *
+     * @return string|null
+     */
+    public function getPaymentMethod()
+    {
+        if (isset($this->data['object']) && 'setup_intent' === $this->data['object']) {
+            return $this->data['payment_method'];
         }
 
         return null;

--- a/src/Message/SetupIntents/Response.php
+++ b/src/Message/SetupIntents/Response.php
@@ -3,10 +3,11 @@
 /**
  * Stripe Payment Intents Response.
  */
+
 namespace Omnipay\Stripe\Message\SetupIntents;
 
 use Omnipay\Common\Message\ResponseInterface;
-use Omnipay\Stripe\Message\Response as BaseResponse;;
+use Omnipay\Stripe\Message\Response as BaseResponse;
 
 /**
  * Stripe Payment Intents Response.

--- a/src/Message/SetupIntents/Response.php
+++ b/src/Message/SetupIntents/Response.php
@@ -1,0 +1,130 @@
+<?php
+
+/**
+ * Stripe Payment Intents Response.
+ */
+namespace Omnipay\Stripe\Message\SetupIntents;
+
+use Omnipay\Common\Message\ResponseInterface;
+use Omnipay\Stripe\Message\Response as BaseResponse;;
+
+/**
+ * Stripe Payment Intents Response.
+ *
+ * This is the response class for all payment intents related responses.
+ *
+ * @see \Omnipay\Stripe\PaymentIntentsGateway
+ */
+class Response extends BaseResponse implements ResponseInterface
+{
+    /**
+     * Get the status of a payment intents response.
+     *
+     * @return string|null
+     */
+    public function getStatus()
+    {
+        if (isset($this->data['object']) && 'setup_intent' === $this->data['object']) {
+            return $this->data['status'];
+        }
+
+        return null;
+    }
+
+    /**
+     * Return true if the payment intent requires confirmation.
+     *
+     * @return bool
+     */
+    public function requiresConfirmation()
+    {
+        return $this->getStatus() === 'requires_confirmation';
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function getClientSecret()
+    {
+        if (isset($this->data['object']) && 'setup_intent' === $this->data['object']) {
+            if (!empty($this->data['client_secret'])) {
+                return $this->data['client_secret'];
+            }
+        }
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function getCustomerReference()
+    {
+
+        if (isset($this->data['object']) && 'setup_intent' === $this->data['object']) {
+            if (!empty($this->data['customer'])) {
+                return $this->data['customer'];
+            }
+        }
+
+        return parent::getCustomerReference();
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function isSuccessful()
+    {
+        if (isset($this->data['object']) && 'setup_intent' === $this->data['object']) {
+            return in_array($this->getStatus(), ['succeeded', 'requires_capture']);
+        }
+
+        return parent::isSuccessful();
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function isCancelled()
+    {
+        if (isset($this->data['object']) && 'setup_intent' === $this->data['object']) {
+            return $this->getStatus() === 'canceled';
+        }
+
+        return parent::isCancelled();
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function isRedirect()
+    {
+        if ($this->getStatus() === 'requires_action' || $this->getStatus() === 'requires_source_action') {
+            // Currently this gateway supports only manual confirmation, so any other
+            // next action types pretty much mean a failed transaction for us.
+            return (!empty($this->data['next_action']) && $this->data['next_action']['type'] === 'redirect_to_url');
+        }
+
+        return parent::isRedirect();
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function getRedirectUrl()
+    {
+        return $this->isRedirect() ? $this->data['next_action']['redirect_to_url']['url'] : parent::getRedirectUrl();
+    }
+
+    /**
+     * Get the payment intent reference.
+     *
+     * @return string|null
+     */
+    public function getSetupIntentReference()
+    {
+        if (isset($this->data['object']) && 'setup_intent' === $this->data['object']) {
+            return $this->data['id'];
+        }
+
+        return null;
+    }
+}

--- a/src/Message/SetupIntents/RetrieveSetupIntentRequest.php
+++ b/src/Message/SetupIntents/RetrieveSetupIntentRequest.php
@@ -3,6 +3,7 @@
 /**
  * Stripe Create Payment Method Request.
  */
+
 namespace Omnipay\Stripe\Message\SetupIntents;
 
 /**
@@ -36,7 +37,7 @@ class RetrieveSetupIntentRequest extends AbstractRequest
      */
     public function getEndpoint()
     {
-        return $this->endpoint.'/setup_intents/'.$this->getSetupIntentReference();
+        return $this->endpoint . '/setup_intents/' . $this->getSetupIntentReference();
     }
 
     public function getHttpMethod()

--- a/src/Message/SetupIntents/RetrieveSetupIntentRequest.php
+++ b/src/Message/SetupIntents/RetrieveSetupIntentRequest.php
@@ -1,0 +1,54 @@
+<?php
+
+/**
+ * Stripe Create Payment Method Request.
+ */
+namespace Omnipay\Stripe\Message\SetupIntents;
+
+/**
+ * Stripe create setup intent
+ *
+ * ### Example
+ *
+ * <code>
+ *
+ * </code>
+ *
+ * @see \Omnipay\Stripe\Message\PaymentIntents\AttachPaymentMethodRequest
+ * @see \Omnipay\Stripe\Message\PaymentIntents\DetachPaymentMethodRequest
+ * @see \Omnipay\Stripe\Message\PaymentIntents\UpdatePaymentMethodRequest
+ * @link https://stripe.com/docs/api/setup_intents/create
+ */
+class RetrieveSetupIntentRequest extends AbstractRequest
+{
+    /**
+     * @inheritdoc
+     */
+    public function getData()
+    {
+        $this->validate('setupIntentReference');
+
+        return [];
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function getEndpoint()
+    {
+        return $this->endpoint.'/setup_intents/'.$this->getSetupIntentReference();
+    }
+
+    public function getHttpMethod()
+    {
+        return 'GET';
+    }
+
+    /**
+     * @inheritdoc
+     */
+    protected function createResponse($data, $headers = [])
+    {
+        return $this->response = new Response($this, $data, $headers);
+    }
+}

--- a/src/PaymentIntentsGateway.php
+++ b/src/PaymentIntentsGateway.php
@@ -166,4 +166,16 @@ class PaymentIntentsGateway extends AbstractGateway
     {
         return $this->createRequest('\Omnipay\Stripe\Message\PaymentIntents\DetachPaymentMethodRequest', $parameters);
     }
+
+    // Setup Intent
+
+    /**
+     * @inheritdoc
+     *
+     * @return \Omnipay\Stripe\Message\SetupIntents\CreateSetupIntentRequest
+     */
+    public function createSetupIntent(array $parameters = array())
+    {
+        return $this->createRequest('\Omnipay\Stripe\Message\SetupIntents\CreateSetupIntentRequest', $parameters);
+    }
 }

--- a/src/PaymentIntentsGateway.php
+++ b/src/PaymentIntentsGateway.php
@@ -3,9 +3,8 @@
 /**
  * Stripe Payment Intents Gateway.
  */
-namespace Omnipay\Stripe;
 
-use Omnipay\Stripe\Message\PaymentIntents\Response;
+namespace Omnipay\Stripe;
 
 /**
  * Stripe Payment Intents Gateway.
@@ -178,6 +177,7 @@ class PaymentIntentsGateway extends AbstractGateway
     {
         return $this->createRequest('\Omnipay\Stripe\Message\SetupIntents\CreateSetupIntentRequest', $parameters);
     }
+
     /**
      * @inheritdoc
      *

--- a/src/PaymentIntentsGateway.php
+++ b/src/PaymentIntentsGateway.php
@@ -178,4 +178,13 @@ class PaymentIntentsGateway extends AbstractGateway
     {
         return $this->createRequest('\Omnipay\Stripe\Message\SetupIntents\CreateSetupIntentRequest', $parameters);
     }
+    /**
+     * @inheritdoc
+     *
+     * @return \Omnipay\Stripe\Message\SetupIntents\CreateSetupIntentRequest
+     */
+    public function retrieveSetupIntent(array $parameters = array())
+    {
+        return $this->createRequest('\Omnipay\Stripe\Message\SetupIntents\RetrieveSetupIntentRequest', $parameters);
+    }
 }


### PR DESCRIPTION
We had to extend the plugin a bit to fit our needs at Ampeco, and I'd like to offer it back to the community. 

The implementation of Session Intent does not cover the full api - just the Create and Retrieve methods are implemented. The rest can be easily added afterwards! 

We also needed the off_session option in payments intent - that why we needed the SetupIntent in the first place :)