### PR TITLE
Update Create plan request

### DIFF
--- a/src/Message/CreatePlanRequest.php
+++ b/src/Message/CreatePlanRequest.php
@@ -78,6 +78,52 @@ class CreatePlanRequest extends AbstractRequest
     }
 
     /**
+     * Set the plan name
+     * @deprecated use setNickname() instead
+     *
+     * @param $value
+     * @return \Omnipay\Common\Message\AbstractRequest|CreatePlanRequest
+     */
+    public function setName($value)
+    {
+        return $this->setNickname($value);
+    }
+
+    /**
+     * Get the plan name
+     * @deprecated use getNickname() instead
+     *
+     * @return string
+     */
+    public function getName()
+    {
+        return $this->getNickname();
+    }
+
+    /**
+     * Set the plan statement descriptor
+     * @deprecated Not used anymore
+     *
+     * @param $planStatementDescriptor
+     * @return \Omnipay\Common\Message\AbstractRequest|CreatePlanRequest
+     */
+    public function setStatementDescriptor($planStatementDescriptor)
+    {
+        return $this->setParameter('statement_descriptor', $planStatementDescriptor);
+    }
+
+    /**
+     * Get the plan statement descriptor
+     * @deprecated Not used anymore
+     *
+     * @return string
+     */
+    public function getStatementDescriptor()
+    {
+        return $this->getParameter('statement_descriptor');
+    }
+
+    /**
      * Set the plan product
      *
      * @param $value

--- a/src/Message/CreatePlanRequest.php
+++ b/src/Message/CreatePlanRequest.php
@@ -10,7 +10,7 @@ namespace Omnipay\Stripe\Message;
  * Stripe Create Plan Request
  *
  * @see \Omnipay\Stripe\Gateway
- * @link https://stripe.com/docs/api#create_plan
+ * @link https://stripe.com/docs/api/plans/create
  */
 class CreatePlanRequest extends AbstractRequest
 {
@@ -78,45 +78,189 @@ class CreatePlanRequest extends AbstractRequest
     }
 
     /**
-     * Set the plan name
+     * Set the plan product
      *
      * @param $value
      * @return \Omnipay\Common\Message\AbstractRequest|CreatePlanRequest
      */
-    public function setName($value)
+    public function setProduct($value)
     {
-        return $this->setParameter('name', $value);
+        return $this->setParameter('product', $value);
     }
 
     /**
-     * Get the plan name
+     * Get the plan product
      *
-     * @return string
+     * @return string|array
      */
-    public function getName()
+    public function getProduct()
     {
-        return $this->getParameter('name');
+        return $this->getParameter('product');
     }
 
     /**
-     * Set the plan statement descriptor
-     *
-     * @param $planStatementDescriptor
+     * Set the plan amount
+     * @param $value
      * @return \Omnipay\Common\Message\AbstractRequest|CreatePlanRequest
      */
-    public function setStatementDescriptor($planStatementDescriptor)
+    public function setAmount($value)
     {
-        return $this->setParameter('statement_descriptor', $planStatementDescriptor);
+        return $this->setParameter('amount', (integer)$value);
     }
 
     /**
-     * Get the plan statement descriptor
+     * Get the plan amount
+     *
+     * @return int
+     */
+    public function getAmount()
+    {
+        return $this->getParameter('amount');
+    }
+
+    /**
+     * Set the plan tiers
+     * @param $value
+     * @return \Omnipay\Common\Message\AbstractRequest|CreatePlanRequest
+     */
+    public function setTiers($value)
+    {
+        return $this->setParameter('tiers', $value);
+    }
+
+    /**
+     * Get the plan tiers
+     *
+     * @return int
+     */
+    public function getTiers()
+    {
+        return $this->getParameter('tiers');
+    }
+
+    /**
+     * Set the plan tiers mode
+     * @param $value
+     * @return \Omnipay\Common\Message\AbstractRequest|CreatePlanRequest
+     */
+    public function setTiersMode($value)
+    {
+        return $this->setParameter('tiers_mode', $value);
+    }
+
+    /**
+     * Get the plan tiers mode
+     *
+     * @return int
+     */
+    public function getTiersMode()
+    {
+        return $this->getParameter('tiers_mode');
+    }
+
+    /**
+     * Set the plan nickname
+     *
+     * @param $value
+     * @return \Omnipay\Common\Message\AbstractRequest|CreatePlanRequest
+     */
+    public function setNickname($value)
+    {
+        return $this->setParameter('nickname', $value);
+    }
+
+    /**
+     * Get the plan nickname
+     *
+     * @return string|array
+     */
+    public function getNickname()
+    {
+        return $this->getParameter('nickname');
+    }
+
+    /**
+     * Set the plan metadata
+     *
+     * @param $value
+     * @return \Omnipay\Common\Message\AbstractRequest|CreatePlanRequest
+     */
+    public function setMetadata($value)
+    {
+        return $this->setParameter('metadata', $value);
+    }
+
+    /**
+     * Get the plan metadata
+     *
+     * @return string|array
+     */
+    public function getMetadata()
+    {
+        return $this->getParameter('metadata');
+    }
+
+    /**
+     * Set the plan active
+     *
+     * @param $value
+     * @return \Omnipay\Common\Message\AbstractRequest|CreatePlanRequest
+     */
+    public function setActive($value)
+    {
+        return $this->setParameter('active', $value);
+    }
+
+    /**
+     * Get the plan active
+     *
+     * @return string|array
+     */
+    public function getActive()
+    {
+        return $this->getParameter('active');
+    }
+
+    /**
+     * Set the plan billingScheme
+     *
+     * @param $value
+     * @return \Omnipay\Common\Message\AbstractRequest|CreatePlanRequest
+     */
+    public function setBillingScheme($value)
+    {
+        return $this->setParameter('billing_scheme', $value);
+    }
+
+    /**
+     * Get the plan billingScheme
+     *
+     * @return string|array
+     */
+    public function getBillingScheme()
+    {
+        return $this->getParameter('billing_scheme');
+    }
+
+    /**
+     * Set the plan aggregate usage
+     *
+     * @param $planAggregateUsage
+     * @return \Omnipay\Common\Message\AbstractRequest|CreatePlanRequest
+     */
+    public function setAggregateUsage($planAggregateUsage)
+    {
+        return $this->setParameter('aggregate_usage', $planAggregateUsage);
+    }
+
+    /**
+     * Get the plan aggregate usage
      *
      * @return string
      */
-    public function getStatementDescriptor()
+    public function getAggregateUsage()
     {
-        return $this->getParameter('statement_descriptor');
+        return $this->getParameter('aggregate_usage');
     }
 
     /**
@@ -140,31 +284,114 @@ class CreatePlanRequest extends AbstractRequest
         return $this->getParameter('trial_period_days');
     }
 
+    /**
+     * Set the plan transform usage
+     *
+     * @param $value
+     * @return \Omnipay\Common\Message\AbstractRequest|CreatePlanRequest
+     */
+    public function setTransformUsage($value)
+    {
+        return $this->setParameter('transform_usage', $value);
+    }
+
+    /**
+     * Get the plan transform usage
+     *
+     * @return int
+     */
+    public function getTransformUsage()
+    {
+        return $this->getParameter('transform_usage');
+    }
+
+    /**
+     * Set the plan usage type
+     *
+     * @param $value
+     * @return \Omnipay\Common\Message\AbstractRequest|CreatePlanRequest
+     */
+    public function setUsageType($value)
+    {
+        return $this->setParameter('usage_type', $value);
+    }
+
+    /**
+     * Get the plan usage type
+     *
+     * @return int
+     */
+    public function getUsageType()
+    {
+        return $this->getParameter('usage_type');
+    }
+
     public function getData()
     {
-        $this->validate('id', 'amount', 'currency', 'interval', 'name');
+        $this->validate('currency', 'interval', 'product');
+
+        if (null == $this->getBillingScheme() || 'per_unit' == $this->getBillingScheme()) {
+            $this->validate('amount');
+        } elseif ('tiered' == $this->getBillingScheme()) {
+            $this->validate('tiers', 'tiers_mode');
+        }
 
         $data = array(
-            'id' => $this->getId(),
-            'amount' => $this->getAmountInteger(),
             'currency' => $this->getCurrency(),
             'interval' => $this->getInterval(),
-            'name' => $this->getName()
+            'product' => $this->getProduct()
         );
 
-        $intervalCount = $this->getIntervalCount();
-        if ($intervalCount != null) {
-            $data['interval_count'] = $intervalCount;
+        if (null != $this->getBillingScheme()) {
+            $data['billing_scheme'] = $this->getBillingScheme();
         }
 
-        $statementDescriptor = $this->getStatementDescriptor();
-        if ($statementDescriptor != null) {
-            $data['statement_descriptor'] = $statementDescriptor;
+        if (null != $this->getId()) {
+            $data['id'] = $this->getId();
         }
 
-        $trialPeriodDays = $this->getTrialPeriodDays();
-        if ($trialPeriodDays != null) {
-            $data['trial_period_days'] = $trialPeriodDays;
+        if (null != $this->getAmount()) {
+            $data['amount'] = $this->getAmount();
+        }
+
+        if (null != $this->getNickName()) {
+            $data['nickname'] = $this->getNickName();
+        }
+
+        if (null != $this->getMetadata()) {
+            $data['metadata'] = $this->getMetadata();
+        }
+
+        if (null != $this->getActive()) {
+            $data['active'] = $this->getActive();
+        }
+
+        if (null != $this->getIntervalCount()) {
+            $data['interval_count'] = $this->getIntervalCount();
+        }
+
+        if (null != $this->getAggregateUsage()) {
+            $data['aggregate_usage'] = $this->getAggregateUsage();
+        }
+
+        if (null != $this->getTrialPeriodDays()) {
+            $data['trial_period_days'] = $this->getTrialPeriodDays();
+        }
+
+        if (null != $this->getTransformUsage()) {
+            $data['transform_usage'] = $this->getTransformUsage();
+        }
+
+        if (null != $this->getUsageType()) {
+            $data['usage_type'] = $this->getUsageType();
+        }
+
+        if (null != $this->getTiers()) {
+            $data['tiers'] = $this->getTiers();
+        }
+
+        if (null != $this->getTiersMode()) {
+            $data['tiers_mode'] = $this->getTiersMode();
         }
 
         return $data;

--- a/tests/Message/CreatePlanRequestTest.php
+++ b/tests/Message/CreatePlanRequestTest.php
@@ -18,9 +18,10 @@ class CreatePlanRequestTest extends TestCase
         $this->request->setAmount('19.00');
         $this->request->setCurrency('usd');
         $this->request->setInterval('month');
-        $this->request->setName('Amazing Gold Plan');
+        $this->request->setNickname('Amazing Gold Plan');
+        $this->request->setProduct('prod_GWN5y0jpQeU9yj');
         $this->request->setIntervalCount(1);
-        $this->request->setStatementDescriptor('Omnipay Basic Plan');
+        $this->request->setActive(false);
         $this->request->setTrialPeriodDays(3);
     }
 
@@ -38,6 +39,7 @@ class CreatePlanRequestTest extends TestCase
         $this->assertFalse($response->isRedirect());
         $this->assertSame('basic', $response->getPlanId());
         $this->assertNotNull($response->getPlan());
+        $this->assertFalse($response->getPlan()['active']);
         $this->assertNull($response->getMessage());
     }
 

--- a/tests/Mock/CreatePlanSuccess.txt
+++ b/tests/Mock/CreatePlanSuccess.txt
@@ -10,14 +10,22 @@ Cache-Control: no-cache, no-store
 {
   "id": "basic",
   "object": "plan",
+  "active": false,
+  "aggregate_usage": null,
   "amount": 1900,
   "created": 1455308594,
   "currency": "usd",
+  "amount_decimal": "2000",
+  "billing_scheme": "per_unit",
   "interval": "month",
   "interval_count": 1,
   "livemode": false,
   "metadata": {},
-  "name": "Amazing Gold Plan",
-  "statement_descriptor": null,
-  "trial_period_days": 3
+  "nickname": "Amazing Gold Plan",
+  "product": "prod_GWN5y0jpQeU9yj",
+  "tiers": null,
+  "tiers_mode": null,
+  "transform_usage": null,
+  "trial_period_days": null,
+  "usage_type": "licensed"
 }


### PR DESCRIPTION
## Deprecated:
`name` and `statement_descriptor` does not exist anymore in Stripe API.


- **setName()** replaced by **setNickName()**
- **getName()** replaced by **getNickName()**
- **setStatementDescriptor()**
- **getStatementDescriptor()**

```
{
  "error": {
    "code": "parameter_unknown",
    "doc_url": "https://stripe.com/docs/error-codes/parameter-unknown",
    "message": "Received unknown parameters: name, statement_descriptor",
    "param": "name",
    "type": "invalid_request_error"
  }
}
```