### PR TITLE
Update CreateSetupIntentRequest

### DIFF
--- a/src/Message/SetupIntents/CreateSetupIntentRequest.php
+++ b/src/Message/SetupIntents/CreateSetupIntentRequest.php
@@ -37,10 +37,10 @@ class CreateSetupIntentRequest extends AbstractRequest
         }
 
         if ($this->getMetadata()) {
-            $this['metadata'] = $this->getMetadata();
+            $data['metadata'] = $this->getMetadata();
         }
         if ($this->getPaymentMethod()) {
-            $this['payment_method'] = $this->getPaymentMethod();
+            $data['payment_method'] = $this->getPaymentMethod();
         }
 
         $data['usage'] = 'off_session';


### PR DESCRIPTION
Stops `CreateSetupIntentRequest` erroring due to setting on `$this` not `$data` in the `getData()` method