### PR TITLE
Add special Response for Checkout Session

### DIFF
--- a/src/Message/Checkout/PurchaseRequest.php
+++ b/src/Message/Checkout/PurchaseRequest.php
@@ -15,6 +15,19 @@ namespace Omnipay\Stripe\Message\Checkout;
 class PurchaseRequest extends AbstractRequest
 {
     /**
+     * Create response
+     *
+     * @param string $data
+     * @param array $headers
+     *
+     * @return Response
+     */
+    protected function createResponse($data, $headers = [])
+    {
+        return $this->response = new Response($this, $data, $headers);
+    }
+
+    /**
      * Set the success url
      *
      * @param string $value

--- a/src/Message/Checkout/Response.php
+++ b/src/Message/Checkout/Response.php
@@ -1,0 +1,33 @@
+<?php namespace Omnipay\Stripe\Message\Checkout;
+
+use Omnipay\Common\Message\AbstractResponse;
+use Omnipay\Common\Message\RedirectResponseInterface;
+use Omnipay\Common\Message\RequestInterface;
+
+/**
+ * Stripe Checkout Response - https://stripe.com/docs/api/checkout/sessions/create
+ *
+ * @see \Omnipay\Stripe\Gateway
+ */
+class Response extends \Omnipay\Stripe\Message\Response
+{
+    /**
+     * @return bool
+     */
+    public function isRedirect()
+    {
+        return $this->getRedirectUrl() !== null;
+    }
+
+    /**
+     * @return mixed
+     */
+    public function getRedirectUrl()
+    {
+        if (isset($this->data['object']) && 'checkout.session' !== $this->data['object']) {
+            return null;
+        }
+
+        return !empty($this->data['url']) ? $this->data['url'] : null;
+    }
+}


### PR DESCRIPTION
Stripe Checkout [Purchase request](https://github.com/thephpleague/omnipay-stripe/blob/master/src/Message/Checkout/PurchaseRequest.php) works fine, but it creates [Stripe Session Response](https://stripe.com/docs/api/checkout/sessions/create) which is not compatible with standard [Response](https://github.com/thephpleague/omnipay-stripe/blob/master/src/Message/Response.php):
- for Checkout there is always redirect, no matter on 3DS availability
-  redirect URL is in `$data['url']` parameter not in `$data['redirect']['url']`

So I've created a new Checkout\Response. With this small fix, isRedirect() returns true and I'm able to redirect to the Checkout gateway.