### PR TITLE
Some parameters made optional

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "enessacid-buker/stripe",
+    "name": "omnipay/stripe",
     "type": "library",
     "description": "Stripe driver for the Omnipay payment processing library",
     "keywords": [

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "omnipay/stripe",
+    "name": "enessacid-buker/stripe",
     "type": "library",
     "description": "Stripe driver for the Omnipay payment processing library",
     "keywords": [

--- a/src/Message/PaymentIntents/AuthorizeRequest.php
+++ b/src/Message/PaymentIntents/AuthorizeRequest.php
@@ -330,6 +330,42 @@ class AuthorizeRequest extends AbstractRequest
     }
 
     /**
+     * @return mixed
+     */
+    public function getConfirmationMethod()
+    {
+        return $this->getParameter('confirmation_method');
+    }
+
+    /**
+     * @param string $value
+     *
+     * @return AbstractRequest provides a fluent interface.
+     */
+    public function setConfirmationMethod($value)
+    {
+        return $this->setParameter('confirmation_method', $value);
+    }
+
+    /**
+     * @return mixed
+     */
+    public function getCaptureMethod()
+    {
+        return $this->getParameter('capture_method');
+    }
+
+    /**
+     * @param string $value
+     *
+     * @return AbstractRequest provides a fluent interface.
+     */
+    public function setCaptureMethod($value)
+    {
+        return $this->setParameter('capture_method', $value);
+    }
+
+    /**
      * @inheritdoc
      */
     public function getData()
@@ -392,8 +428,13 @@ class AuthorizeRequest extends AbstractRequest
 
         $data['off_session'] = $this->getOffSession() ? 'true' : 'false';
 
-        $data['confirmation_method'] = 'manual';
-        $data['capture_method'] = 'manual';
+        if ($this->getConfirmationMethod()) {
+            $data['confirmation_method'] = $this->getConfirmationMethod();
+        }
+
+        if ($this->getCaptureMethod()) {
+            $data['capture_method'] = $this->getCaptureMethod();
+        }
 
         $data['confirm'] = $this->getConfirm() ? 'true' : 'false';
 

--- a/src/Message/PaymentIntents/CreatePaymentMethodRequest.php
+++ b/src/Message/PaymentIntents/CreatePaymentMethodRequest.php
@@ -117,7 +117,7 @@ class CreatePaymentMethodRequest extends AbstractRequest
                 'country' => $data['address_country'],
                 'line1' => $data['address_line1'],
                 'line2' => $data['address_line2'],
-                'postal_code' => $data['address_zip'],
+                'postal_code' => $data['address_zip'] ?? null,
                 'state' => $data['address_state'],
             ]),
         ]);


### PR DESCRIPTION
I ran into some issues when creating the PaymentIntent as the [`confirmation_method`](https://stripe.com/docs/api/payment_intents/create#create_payment_intent-confirmation_method
) and [`capture_method`](https://stripe.com/docs/api/payment_intents/create#create_payment_intent-capture_method) parameters could not be set a value.