### PR TITLE
Send client_reference_id with PurchaseRequest

### DIFF
--- a/src/Message/Checkout/PurchaseRequest.php
+++ b/src/Message/Checkout/PurchaseRequest.php
@@ -149,6 +149,7 @@ class PurchaseRequest extends AbstractRequest
     public function getData()
     {
         $data = array(
+            'client_reference_id' => $this->getClientReferenceId(),
             'success_url' => $this->getSuccessUrl(),
             'cancel_url' => $this->getCancelUrl(),
             'payment_method_types' => $this->getPaymentMethodTypes(),

--- a/src/Message/Checkout/PurchaseRequest.php
+++ b/src/Message/Checkout/PurchaseRequest.php
@@ -145,6 +145,27 @@ class PurchaseRequest extends AbstractRequest
         return $this->getParameter('client_reference_id');
     }
 
+    /**
+     * Set the customer_creation parameter
+     *
+     * @param string $value
+     *
+     * @return \Omnipay\Common\Message\AbstractRequest|PurchaseRequest
+     */
+    public function setCustomerCreation($value)
+    {
+        return $this->setParameter('customer_creation', $value);
+    }
+
+    /**
+     * Get the customer_creation parameter
+     *
+     * @return string
+     */
+    public function getCustomerCreation()
+    {
+        return $this->getParameter('customer_creation');
+    }
 
     public function getData()
     {
@@ -154,6 +175,7 @@ class PurchaseRequest extends AbstractRequest
             'cancel_url' => $this->getCancelUrl(),
             'payment_method_types' => $this->getPaymentMethodTypes(),
             'mode' => $this->getMode(),
+            'customer_creation' => $this->getCustomerCreation(),
             'line_items' => $this->getLineItems()
         );
 

--- a/src/Message/PaymentIntents/AuthorizeRequest.php
+++ b/src/Message/PaymentIntents/AuthorizeRequest.php
@@ -330,6 +330,42 @@ class AuthorizeRequest extends AbstractRequest
     }
 
     /**
+     * @return mixed
+     */
+    public function getConfirmationMethod()
+    {
+        return $this->getParameter('confirmation_method');
+    }
+
+    /**
+     * @param string $value
+     *
+     * @return AbstractRequest provides a fluent interface.
+     */
+    public function setConfirmationMethod($value)
+    {
+        return $this->setParameter('confirmation_method', $value);
+    }
+
+    /**
+     * @return mixed
+     */
+    public function getCaptureMethod()
+    {
+        return $this->getParameter('capture_method');
+    }
+
+    /**
+     * @param string $value
+     *
+     * @return AbstractRequest provides a fluent interface.
+     */
+    public function setCaptureMethod($value)
+    {
+        return $this->setParameter('capture_method', $value);
+    }
+
+    /**
      * @inheritdoc
      */
     public function getData()
@@ -392,8 +428,13 @@ class AuthorizeRequest extends AbstractRequest
 
         $data['off_session'] = $this->getOffSession() ? 'true' : 'false';
 
-        $data['confirmation_method'] = 'manual';
-        $data['capture_method'] = 'manual';
+        if ($this->getConfirmationMethod()) {
+            $data['confirmation_method'] = $this->getConfirmationMethod();
+        }
+
+        if ($this->getCaptureMethod()) {
+            $data['capture_method'] = $this->getCaptureMethod();
+        }
 
         $data['confirm'] = $this->getConfirm() ? 'true' : 'false';
 

--- a/src/Message/PaymentIntents/CreatePaymentMethodRequest.php
+++ b/src/Message/PaymentIntents/CreatePaymentMethodRequest.php
@@ -117,7 +117,7 @@ class CreatePaymentMethodRequest extends AbstractRequest
                 'country' => $data['address_country'],
                 'line1' => $data['address_line1'],
                 'line2' => $data['address_line2'],
-                'postal_code' => $data['address_zip'],
+                'postal_code' => $data['address_zip'] ?? null,
                 'state' => $data['address_state'],
             ]),
         ]);

--- a/tests/Message/Checkout/PurchaseRequestTest.php
+++ b/tests/Message/Checkout/PurchaseRequestTest.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace Omnipay\Stripe\Message\Checkout;
+
+use Omnipay\Tests\TestCase;
+
+class PurchaseRequestTest extends TestCase
+{
+    /**
+     * @var PurchaseRequest
+     */
+    protected $request;
+
+    public function setUp()
+    {
+        $this->request = new PurchaseRequest($this->getHttpClient(), $this->getHttpRequest());
+        $this->request->initialize(
+            array(
+                'client_reference_id' => 'cart_id_123'
+            )
+        );
+    }
+
+    public function testGetData()
+    {
+        $data = $this->request->getData();
+
+        $this->assertSame('cart_id_123', $data['client_reference_id']);
+    }
+
+}


### PR DESCRIPTION
There is no way to get the internal reference back from Stripe in a webhook for a Checkout PurchaseRequest because the client_reference_id is not sent to the API.

This pull request adds the missing data to the request, with tests.