### PR TITLE
URGENT!!! stripe deprecated the charges object from payment intent object

### DIFF
--- a/src/Message/PaymentIntents/Response.php
+++ b/src/Message/PaymentIntents/Response.php
@@ -106,19 +106,13 @@ class Response extends BaseResponse implements RedirectResponseInterface
             }
         }
 
-        return parent::getTransactionReference();
-    }
-
-    /**
-     * @inheritdoc
-     */
-    public function isSuccessful()
-    {
         if (isset($this->data['object']) && 'payment_intent' === $this->data['object']) {
-            return in_array($this->getStatus(), ['succeeded', 'requires_capture']);
+            if (!empty($this->data['latest_charge'])) {
+                return $this->data['latest_charge'];
+            }
         }
 
-        return parent::isSuccessful();
+        return parent::getTransactionReference();
     }
 
     /**
@@ -131,6 +125,18 @@ class Response extends BaseResponse implements RedirectResponseInterface
         }
 
         return parent::isCancelled();
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function isSuccessful()
+    {
+        if (isset($this->data['object']) && 'payment_intent' === $this->data['object']) {
+            return in_array($this->getStatus(), ['succeeded', 'requires_capture']);
+        }
+
+        return parent::isSuccessful();
     }
 
     /**

--- a/tests/Message/PaymentIntents/Mock/PurchaseSuccess.txt
+++ b/tests/Message/PaymentIntents/Mock/PurchaseSuccess.txt
@@ -20,109 +20,6 @@ Access-Control-Max-Age: 300
   "canceled_at": null,
   "cancellation_reason": null,
   "capture_method": "automatic",
-  "charges": {
-    "object": "list",
-    "data": [
-      {
-        "id": "ch_1EW0FmFSbr6xR4YAZyURWxQe",
-        "object": "charge",
-        "amount": 8000,
-        "amount_refunded": 0,
-        "application": null,
-        "application_fee": null,
-        "application_fee_amount": null,
-        "balance_transaction": "txn_1EW0FnFSbr6xR4YAOVasO6Eu",
-        "billing_details": {
-          "address": {
-            "city": "Riga",
-            "country": "United States",
-            "line1": "GARRISON DRIVE 60837",
-            "line2": null,
-            "postal_code": "97702",
-            "state": null
-          },
-          "email": "andris@shift.lv",
-          "name": "Janice Friend",
-          "phone": null
-        },
-        "captured": true,
-        "created": 1556885558,
-        "currency": "usd",
-        "customer": "cus_F0026biLhRIcO9",
-        "description": "Order #34",
-        "destination": null,
-        "dispute": null,
-        "failure_code": null,
-        "failure_message": null,
-        "fraud_details": {
-        },
-        "invoice": null,
-        "livemode": false,
-        "metadata": {
-          "order_id": "34",
-          "order_number": "aaefd8ec96095c47ed0c665666c3c768",
-          "transaction_reference": "84aaac664c7048000146d3a88b5f0081",
-          "client_ip": "::1"
-        },
-        "on_behalf_of": null,
-        "order": null,
-        "outcome": {
-          "network_status": "approved_by_network",
-          "reason": null,
-          "risk_level": "normal",
-          "risk_score": 21,
-          "seller_message": "Payment complete.",
-          "type": "authorized"
-        },
-        "paid": true,
-        "payment_intent": "pi_1EW0FmFSbr6xR4YAvECSRCv2",
-        "payment_method": "pm_1EW0FPFSbr6xR4YAZOSMHIOE",
-        "payment_method_details": {
-          "card": {
-            "brand": "visa",
-            "checks": {
-              "address_line1_check": "pass",
-              "address_postal_code_check": "pass",
-              "cvc_check": "pass"
-            },
-            "country": "US",
-            "description": "Visa Classic",
-            "exp_month": 12,
-            "exp_year": 2020,
-            "fingerprint": "ZpBtWK0wNH3oi8mw",
-            "funding": "credit",
-            "last4": "4242",
-            "three_d_secure": null,
-            "wallet": null
-          },
-          "type": "card"
-        },
-        "receipt_email": null,
-        "receipt_number": null,
-        "receipt_url": "https://pay.stripe.com/receipts/acct_1AjnbxFSbr6xR4YA/ch_1EW0FmFSbr6xR4YAZyURWxQe/rcpt_F00G6tmZch7lV8HQbMulDt61Fd2T3Co",
-        "refunded": false,
-        "refunds": {
-          "object": "list",
-          "data": [
-          ],
-          "has_more": false,
-          "total_count": 0,
-          "url": "/v1/charges/ch_1EW0FmFSbr6xR4YAZyURWxQe/refunds"
-        },
-        "review": null,
-        "shipping": null,
-        "source": null,
-        "source_transfer": null,
-        "statement_descriptor": null,
-        "status": "succeeded",
-        "transfer_data": null,
-        "transfer_group": null
-      }
-    ],
-    "has_more": false,
-    "total_count": 1,
-    "url": "/v1/charges?payment_intent=pi_1EW0FmFSbr6xR4YAvECSRCv2"
-  },
   "client_secret": "pi_1EW0FmFSbr6xR4YAvECSRCv2_secret_kUQ34vTWkFRAECbpbswOpAuus",
   "confirmation_method": "automatic",
   "created": 1556885558,
@@ -131,6 +28,7 @@ Access-Control-Max-Age: 300
   "description": "Order #34",
   "invoice": null,
   "last_payment_error": null,
+  "latest_charge": "ch_1EW0FmFSbr6xR4YAZyURWxQe",
   "livemode": false,
   "metadata": {
     "order_id": "34",


### PR DESCRIPTION
As of November 16, 2022, Stripe removed the **charges** object in the **PaymentIntent** object/response.  

See their comment from here:
<img width="1089" alt="Screenshot 2023-10-09 at 9 14 51 AM" src="https://github.com/thephpleague/omnipay-stripe/assets/6128004/45ea3095-5244-4675-8106-f0a9325bfba8">
Link `[here](https://stripe.com/docs/changelog)` 

I want to note that there was an existing test case failure outside to this changes. 
