### PR TITLE
added statement_descriptor_suffix paramater

### DIFF
--- a/src/Message/AuthorizeRequest.php
+++ b/src/Message/AuthorizeRequest.php
@@ -211,6 +211,18 @@ class AuthorizeRequest extends AbstractRequest
         return $this->setParameter('statementDescriptor', $value);
     }
 
+    public function getStatementDescriptorSuffix()
+    {
+        return $this->getParameter('statementDescriptorSuffix');
+    }
+
+    public function setStatementDescriptorSuffix($value)
+    {
+        $value = str_replace(array('<', '>', '"', '\''), '', $value);
+
+        return $this->setParameter('statementDescriptorSuffix', $value);
+    }
+
     /**
      * @return mixed
      */
@@ -307,6 +319,11 @@ class AuthorizeRequest extends AbstractRequest
         if ($this->getStatementDescriptor()) {
             $data['statement_descriptor'] = $this->getStatementDescriptor();
         }
+
+        if ($this->getStatementDescriptorSuffix()) {
+            $data['statement_descriptor_suffix'] = $this->getStatementDescriptorSuffix();
+        }
+
         if ($this->getDestination()) {
             $data['destination'] = $this->getDestination();
         }

--- a/src/Message/PaymentIntents/AuthorizeRequest.php
+++ b/src/Message/PaymentIntents/AuthorizeRequest.php
@@ -271,6 +271,26 @@ class AuthorizeRequest extends AbstractRequest
     /**
      * @return mixed
      */
+    public function getStatementDescriptorSuffix()
+    {
+        return $this->getParameter('statementDescriptorSuffix');
+    }
+
+    /**
+     * @param string $value
+     *
+     * @return AbstractRequest provides a fluent interface.
+     */
+    public function setStatementDescriptorSuffix($value)
+    {
+        $value = str_replace(array('<', '>', '"', '\''), '', $value);
+
+        return $this->setParameter('statementDescriptorSuffix', $value);
+    }
+
+    /**
+     * @return mixed
+     */
     public function getReceiptEmail()
     {
         return $this->getParameter('receipt_email');
@@ -382,6 +402,11 @@ class AuthorizeRequest extends AbstractRequest
         if ($this->getStatementDescriptor()) {
             $data['statement_descriptor'] = $this->getStatementDescriptor();
         }
+
+        if ($this->getStatementDescriptorSuffix()) {
+            $data['statement_descriptor_suffix'] = $this->getStatementDescriptorSuffix();
+        }
+
         if ($this->getDestination()) {
             $data['transfer_data']['destination'] = $this->getDestination();
         }


### PR DESCRIPTION
Added the statement_descriptor_suffix parameter. The statement_descriptor parameter is not allowed for card charges, as per the Stripe docs:

> Use the statement_descriptor parameter to set the complete statement descriptor for non-card charges. Attempting to set this parameter for card charges results in a 400 error. For payments made with a card, use statement_descriptor_suffix instead.