### PR TITLE
passing currency as a string to DecimalMoneyParser is not supported

### DIFF
--- a/src/Message/AbstractRequest.php
+++ b/src/Message/AbstractRequest.php
@@ -324,7 +324,7 @@ abstract class AbstractRequest extends \Omnipay\Common\Message\AbstractRequest
                 throw new InvalidRequestException('Amount precision is too high for currency.');
             }
 
-            $money = $moneyParser->parse((string) $number, $currency->getCode());
+            $money = $moneyParser->parse((string) $number, $currency);
 
             // Check for a negative amount.
             if (!$this->negativeAmountAllowed && $money->isNegative()) {


### PR DESCRIPTION
Omnipay/common supports moneyphp 3.1 and 4, but in AbstractRequest::getMoney currency is passed to the money parser as a string which is deprecated in 3.1 and unsupported in 4. I noticed this when using the applicationFee param which does not work because of this with Money PHP 4.

This fix works with both Money 3.1 and 4. 