### PR TITLE
Feature/application fee fix

### DIFF
--- a/src/Message/AuthorizeRequest.php
+++ b/src/Message/AuthorizeRequest.php
@@ -316,7 +316,7 @@ class AuthorizeRequest extends AbstractRequest
         }
 
         if ($this->getApplicationFee()) {
-            $data['application_fee'] = $this->getApplicationFeeInteger();
+            $data['application_fee_amount'] = $this->getApplicationFeeInteger();
         }
 
         if ($this->getTransferGroup()) {

--- a/src/Message/PaymentIntents/AuthorizeRequest.php
+++ b/src/Message/PaymentIntents/AuthorizeRequest.php
@@ -391,7 +391,7 @@ class AuthorizeRequest extends AbstractRequest
         }
 
         if ($this->getApplicationFee()) {
-            $data['application_fee'] = $this->getApplicationFeeInteger();
+            $data['application_fee_amount'] = $this->getApplicationFeeInteger();
         }
 
         if ($this->getTransferGroup()) {

--- a/src/Message/PaymentIntents/CaptureRequest.php
+++ b/src/Message/PaymentIntents/CaptureRequest.php
@@ -5,6 +5,8 @@
  */
 namespace Omnipay\Stripe\Message\PaymentIntents;
 
+use Money\Formatter\DecimalMoneyFormatter;
+
 /**
  * Stripe Capture Request.
  *
@@ -39,8 +41,55 @@ class CaptureRequest extends AbstractRequest
             $data['amount_to_capture'] = $amount;
         }
 
+        if ($this->getApplicationFee()) {
+            $data['application_fee_amount'] = $this->getApplicationFeeInteger();
+        }
+
         return $data;
     }
+
+    /**
+     * @return string
+     * @throws \Omnipay\Common\Exception\InvalidRequestException
+     */
+    public function getApplicationFee()
+    {
+        $money = $this->getMoney('applicationFee');
+
+        if ($money !== null) {
+            return (new DecimalMoneyFormatter($this->getCurrencies()))->format($money);
+        }
+
+        return '';
+    }
+
+    /**
+     * Get the payment amount as an integer.
+     *
+     * @return integer
+     * @throws \Omnipay\Common\Exception\InvalidRequestException
+     */
+    public function getApplicationFeeInteger()
+    {
+        $money = $this->getMoney('applicationFee');
+
+        if ($money !== null) {
+            return (integer) $money->getAmount();
+        }
+
+        return 0;
+    }
+
+    /**
+     * @param string $value
+     *
+     * @return AbstractRequest provides a fluent interface.
+     */
+    public function setApplicationFee($value)
+    {
+        return $this->setParameter('applicationFee', $value);
+    }
+
 
     public function getEndpoint()
     {

--- a/tests/Message/AuthorizeRequestTest.php
+++ b/tests/Message/AuthorizeRequestTest.php
@@ -39,7 +39,7 @@ class AuthorizeRequestTest extends TestCase
         $this->assertSame('Order #42', $data['description']);
         $this->assertSame('false', $data['capture']);
         $this->assertSame(array('foo' => 'bar'), $data['metadata']);
-        $this->assertSame(100, $data['application_fee']);
+        $this->assertSame(100, $data['application_fee_amount']);
     }
 
     public function testDataWithLevel3()

--- a/tests/Message/PaymentIntents/AuthorizeRequestTest.php
+++ b/tests/Message/PaymentIntents/AuthorizeRequestTest.php
@@ -43,7 +43,7 @@ class AuthorizeRequestTest extends TestCase
         $this->assertSame('manual', $data['confirmation_method']);
         $this->assertSame('pm_valid_payment_method', $data['payment_method']);
         $this->assertSame(array('foo' => 'bar'), $data['metadata']);
-        $this->assertSame(100, $data['application_fee']);
+        $this->assertSame(100, $data['application_fee_amount']);
         $this->assertSame('off_session', $data['setup_future_usage']);
         $this->assertSame('false', $data['off_session']);
     }

--- a/tests/Message/PaymentIntents/PurchaseRequestTest.php
+++ b/tests/Message/PaymentIntents/PurchaseRequestTest.php
@@ -39,7 +39,7 @@ class PurchaseRequestTest extends TestCase
         $this->assertSame('manual', $data['confirmation_method']);
         $this->assertSame('pm_valid_payment_method', $data['payment_method']);
         $this->assertSame(array('foo' => 'bar'), $data['metadata']);
-        $this->assertSame(100, $data['application_fee']);
+        $this->assertSame(100, $data['application_fee_amount']);
     }
 
     public function testSendSuccessAndRequireConfirmation()


### PR DESCRIPTION
The Application Fee parameter should be application_fee_amount, not just application_fee. See https://stripe.com/docs/api/payment_intents/object#payment_intent_object-application_fee_amount

This pull request also adds support to Capture to change the application fee (if using a percentage-based fee).