### PR TITLE
Clone payment methods for use in connected stripe account

### DIFF
--- a/src/Message/PaymentIntents/ClonePaymentMethodRequest.php
+++ b/src/Message/PaymentIntents/ClonePaymentMethodRequest.php
@@ -1,0 +1,48 @@
+<?php
+
+/**
+ * Stripe Create Payment Method Request.
+ */
+namespace Omnipay\Stripe\Message\PaymentIntents;
+
+/**
+ * Clone a payment method to a connected Stripe account.
+ *
+ * @see \Omnipay\Stripe\Message\PaymentIntents\AttachPaymentMethodRequest
+ * @see \Omnipay\Stripe\Message\PaymentIntents\DetachPaymentMethodRequest
+ * @see \Omnipay\Stripe\Message\PaymentIntents\UpdatePaymentMethodRequest
+ * @link https://docs.stripe.com/payments/payment-methods/connect?lang=php#cloning-payment-methods
+ */
+class ClonePaymentMethodRequest extends AbstractRequest
+{
+    /**
+     * @inheritdoc
+     */
+    public function getData()
+    {
+        $data = [];
+
+        $this->validate('customerReference', 'paymentMethod');
+
+        $data['payment_method'] = $this->getPaymentMethod();
+        $data['customer'] = $this->getCustomerReference();
+        
+        return $data;
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function getEndpoint()
+    {
+        return $this->endpoint.'/payment_methods';
+    }
+
+    /**
+     * @inheritdoc
+     */
+    protected function createResponse($data, $headers = [])
+    {
+        return $this->response = new Response($this, $data, $headers);
+    }
+}

--- a/src/PaymentIntentsGateway.php
+++ b/src/PaymentIntentsGateway.php
@@ -166,6 +166,16 @@ class PaymentIntentsGateway extends AbstractGateway
         return $this->createRequest('\Omnipay\Stripe\Message\PaymentIntents\DetachPaymentMethodRequest', $parameters);
     }
 
+    /**
+     * Clone a Payment Method to a Connected Stripe account.
+     *
+     * @return \Omnipay\Stripe\Message\PaymentIntents\ClonePaymentMethodRequest
+     */
+    public function clonePaymentMethod(array $parameters = array())
+    {
+        return $this->createRequest('\Omnipay\Stripe\Message\PaymentIntents\ClonePaymentMethodRequest', $parameters);
+    }
+    
     // Setup Intent
 
     /**


### PR DESCRIPTION
New Request type on PaymentIntents gateway to allow for cloning of payment methods to connected Stripe accounts:
https://docs.stripe.com/payments/payment-methods/connect?lang=php#cloning-payment-methods